### PR TITLE
Context should work with raw string as well

### DIFF
--- a/internal/pkg/pipeline/record/record.go
+++ b/internal/pkg/pipeline/record/record.go
@@ -12,6 +12,17 @@ type Record struct {
 	Context context.Context `yaml:"-" json:"-"`
 }
 
+func (m Record) MarshalJSON() ([]byte, error) {
+    type Alias Record // Prevent recursion
+    return json.Marshal(&struct {
+        Data string `json:"data"`
+        *Alias
+    }{
+        Data:  string(m.Data),
+        Alias: (*Alias)(&m),
+    })
+}
+
 func (r *Record) Bytes() []byte {
 
 	data, _ := json.Marshal(r)

--- a/internal/pkg/pipeline/task/task.go
+++ b/internal/pkg/pipeline/task/task.go
@@ -117,13 +117,16 @@ func (b *Base) SendRecord(r *record.Record, output chan<- *record.Record) /* we 
 		output <- r
 	}()
 
-	if b.Context == nil {
+	// before we set context, let's serialize the whole record
+	data, err := json.Marshal(r)
+	if err != nil {
+		// TODO: do prom metrics / log event to syslog
+		fmt.Println(`ERROR (marshal):`, err)
 		return
 	}
-
 	// Set the context values for the record
 	for name, query := range b.Context {
-		queryResult, err := query.Execute(r.Data)
+		queryResult, err := query.Execute(data)
 		if err != nil {
 			// TODO: do prom metrics / log event to syslog
 			fmt.Println(`ERROR (query):`, err)

--- a/test/pipelines/context_test.yaml
+++ b/test/pipelines/context_test.yaml
@@ -3,10 +3,10 @@ tasks:
     type: http
     endpoint: https://jsonplaceholder.typicode.com/users/2
     context:
-      user_id: ".id"
-      user_name: ".name"
-      user_email: ".email"
-      user_company: ".company.name"
+      user_id: ".data | fromjson | .id"
+      user_name: ".data | fromjson | .name"
+      user_email: ".data | fromjson | .email"
+      user_company: ".data | fromjson | .company.name"
   
   - name: form_posts_endpoint_with_context
     type: jq

--- a/test/pipelines/hello_name.yaml
+++ b/test/pipelines/hello_name.yaml
@@ -4,7 +4,7 @@ tasks:
     path: names.txt
     context:
       names: '.data | split("\n") | shuffle | .[:10]'
-      origin: '.origin'
+      origin: ".origin"
   - name: split_to_lines
     type: split
   - name: random


### PR DESCRIPTION
## Background
Sometimes record.Data is not json but even in that case we want to be able to work with them as we do with json records in context.

## Change
If record.Data is not json don't throw an error send it as string to jq. 

## Test 
Testing with hello_name.yaml and context_test
