### PR TITLE
Update converter task to take column names from first row in CSV.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The system is particularly useful for:
 
 2. **Build the project:**
    ```bash
-   go build -o caterpillar cmd/unified-ingestor/unified-ingestor.go
+   go build -o caterpillar ./cmd/caterpillar/caterpillar.go
    ```
 
 3. **Run a pipeline:**

--- a/internal/pkg/pipeline/task/converter/README.md
+++ b/internal/pkg/pipeline/task/converter/README.md
@@ -24,7 +24,7 @@ The converter task transforms data between different formats. It receives record
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `skip_first` | bool | `false` | Skip the first record (useful for headers) |
-| `take_column_names_from_first_row` | bool | `false` | Name columns using column headers in CSV.  If setting to true, set skip_first to true also.
+| `take_column_names_from_first_row` | bool | `false` | Name columns using values in first row of CSV.  If setting to true, then skip_first is not needed.
 | `columns` | array | - | Array of column definitions |
 | `columns[].name` | string | - | Name for the column |
 | `columns[].is_numeric` | bool | `false` | Whether the column contains numeric data |

--- a/internal/pkg/pipeline/task/converter/README.md
+++ b/internal/pkg/pipeline/task/converter/README.md
@@ -17,13 +17,14 @@ The converter task transforms data between different formats. It receives record
 | `name` | string | - | Task name for identification |
 | `type` | string | `converter` | Must be "converter" |
 | `format` | string | - | Format to convert to (csv, html, sst) |
-| `delimeter` | string| \t | Used only in sst converter for spliting key and value| 
+| `delimiter` | string| \t | Used only in sst converter for spliting key and value| 
 
 ### CSV Format Options
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `skip_first` | bool | `false` | Skip the first record (useful for headers) |
+| `take_column_names_from_first_row` | bool | `false` | Name columns using column headers in CSV.  If setting to true, set skip_first to true also.
 | `columns` | array | - | Array of column definitions |
 | `columns[].name` | string | - | Name for the column |
 | `columns[].is_numeric` | bool | `false` | Whether the column contains numeric data |
@@ -59,6 +60,15 @@ tasks:
       - name: email
       - name: age
         is_numeric: true
+```
+or
+```yaml
+tasks:
+  - name: csv_to_json_use_column_headers
+    type: converter
+    format: csv
+    skip_first: true
+    take_column_names_from_first_row: true
 ```
 
 ### HTML to JSON conversion:

--- a/internal/pkg/pipeline/task/converter/csv.go
+++ b/internal/pkg/pipeline/task/converter/csv.go
@@ -16,14 +16,14 @@ type csvColumn struct {
 }
 
 type csv struct {
-	SkipFirst          bool         `yaml:"skip_first,omitempty" json:"skip_first,omitempty"`
-	TakeNamesFromFirst bool         `yaml:"take_names_from_first,omitempty" json:"take_names_from_first,omitempty"`
-	Columns            []*csvColumn `yaml:"columns" json:"columns"`
+	SkipFirst                   bool         `yaml:"skip_first,omitempty" json:"skip_first,omitempty"`
+	TakeColumnNamesFromFirstRow bool         `yaml:"take_column_names_from_first_row,omitempty" json:"take_column_names_from_first_row,omitempty"`
+	Columns                     []*csvColumn `yaml:"columns" json:"columns"`
 }
 
 func (c *csv) convert(data []byte, _ string) ([]byte, error) {
 
-	if c.TakeNamesFromFirst {
+	if c.TakeColumnNamesFromFirstRow {
 		reader := ec.NewReader(bytes.NewReader(data))
 		header, err := reader.Read()
 		if err != nil {
@@ -34,7 +34,7 @@ func (c *csv) convert(data []byte, _ string) ([]byte, error) {
 			c.Columns[i] = &csvColumn{Name: strings.ToLower(regexp.MustCompile(`[^a-zA-Z0-9]+`).ReplaceAllString(name, "_"))}
 		}
 		c.SkipFirst = false // in case it was set to true, we already read the first line which is the header, and don't want to skip the next line
-		c.TakeNamesFromFirst = false
+		c.TakeColumnNamesFromFirstRow = false
 		return nil, nil
 	}
 

--- a/internal/pkg/pipeline/task/converter/csv.go
+++ b/internal/pkg/pipeline/task/converter/csv.go
@@ -5,6 +5,7 @@ import (
 	ec "encoding/csv"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -15,11 +16,27 @@ type csvColumn struct {
 }
 
 type csv struct {
-	SkipFirst bool         `yaml:"skip_first,omitempty" json:"skip_first,omitempty"`
-	Columns   []*csvColumn `yaml:"columns" json:"columns"`
+	SkipFirst          bool         `yaml:"skip_first,omitempty" json:"skip_first,omitempty"`
+	TakeNamesFromFirst bool         `yaml:"take_names_from_first,omitempty" json:"take_names_from_first,omitempty"`
+	Columns            []*csvColumn `yaml:"columns" json:"columns"`
 }
 
 func (c *csv) convert(data []byte, _ string) ([]byte, error) {
+
+	if c.TakeNamesFromFirst {
+		reader := ec.NewReader(bytes.NewReader(data))
+		header, err := reader.Read()
+		if err != nil {
+			return nil, err
+		}
+		c.Columns = make([]*csvColumn, len(header))
+		for i, name := range header {
+			c.Columns[i] = &csvColumn{Name: strings.ToLower(regexp.MustCompile(`[^a-zA-Z0-9]+`).ReplaceAllString(name, "_"))}
+		}
+		c.SkipFirst = false // in case it was set to true, we already read the first line which is the header, and don't want to skip the next line
+		c.TakeNamesFromFirst = false
+		return nil, nil
+	}
 
 	if c.SkipFirst {
 		c.SkipFirst = false


### PR DESCRIPTION
This PR adds support for automatically using column headers from the first row of CSV files as column names in the converter task, eliminating the need to manually define column names in the configuration.

Introduces a new configuration option take_column_names_from_first_row that automatically generates column definitions from CSV headers
Updates documentation to include the new option and fix spelling errors
Corrects the build command in the main README