### PR TITLE
Improve logic in sst

### DIFF
--- a/internal/pkg/pipeline/task/converter/sst.go
+++ b/internal/pkg/pipeline/task/converter/sst.go
@@ -25,7 +25,6 @@ func (c *sst) convert(data []byte, d string) ([]byte, error) {
 		if line == "" {
 			continue
 		}
-		line = strings.TrimSpace(line)[1 : len(line)-1]
 		kv := strings.SplitN(line, d, 2)
 		if len(kv) != 2 {
 			return nil, errors.New("invalid input for sst converter: expected 'key" + d + "value' format (got: " + line + ")")


### PR DESCRIPTION
## Description
Converter to sst will be after jq+join operations. With this refactor, the SST converter no longer assumes that input strings include starting or ending quotation marks - a behavior present in the current implementation.
Previously, all keys and values in the SST were quoted, which introduced unnecessary complexity and overhead when reading data. This update simplifies both the user experience and performance: values are now handled as raw strings, reducing the need for additional parsing or unquoting during read operations.

## Tests
On local machine 