### PR TITLE
add context node_index to xpath output records

### DIFF
--- a/internal/pkg/pipeline/task/xpath/README.md
+++ b/internal/pkg/pipeline/task/xpath/README.md
@@ -21,6 +21,16 @@ The XPath task extracts structured data from XML and HTML documents using XPath 
 | `ignore_missing` | bool | `true` | Whether to ignore missing fields |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
 
+## Context Variables
+
+When using a container XPath that matches one or more nodes, the task sets the following context variable for each output record:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `node_index` | string | 1-based index of the container node (e.g., "1", "2", "3") |
+
+This allows downstream tasks to track which container element the data was extracted from, useful for maintaining order or grouping related data.
+
 ## Example Configurations
 
 ### Extract multiple fields from HTML:
@@ -76,13 +86,15 @@ tasks:
 ## Sample Pipelines
 
 - `test/pipelines/xpath.yaml` - XPath extraction examples
+- `test/pipelines/xpath_with_index.yaml` - Xpath extraction with node index example
 - `test/pipelines/html2json.yaml` - HTML to JSON conversion
 
 ## Use Cases
 
-- **Web scraping**: Extract data from HTML web pages
+- **Web scraping**: Extract data from HTML web pages with node indexing for tracking
 - **XML processing**: Parse and extract data from XML documents
 - **Data extraction**: Extract structured data from semi-structured sources
 - **Content analysis**: Analyze web page content and structure
 - **API response processing**: Extract data from XML API responses
 - **Document processing**: Parse XML-based document formats
+- **Multi-record extraction**: Process multiple similar elements while preserving their order

--- a/internal/pkg/pipeline/task/xpath/xpath.go
+++ b/internal/pkg/pipeline/task/xpath/xpath.go
@@ -14,6 +14,8 @@ import (
 	"github.com/patterninc/caterpillar/internal/pkg/pipeline/task/converter"
 )
 
+const nodeIndexKey = "node_index"
+
 type xpath struct {
 	task.Base     `yaml:",inline" json:",inline"`
 	Container     string            `yaml:"container" json:"container"`
@@ -50,13 +52,15 @@ func (x *xpath) Run(input <-chan *record.Record, output chan<- *record.Record) e
 			}
 		}
 
-		for _, container := range containerNodes {
+		for i, container := range containerNodes {
 			data, err := x.queryFields(container)
 			if err != nil {
 				return err
 			}
 
 			if len(data) != 0 {
+				index := fmt.Sprintf("%d", i+1)
+				r.SetContextValue(nodeIndexKey, index)
 				x.SendData(r.Context, data, output)
 			}
 		}

--- a/test/pipelines/sample.html
+++ b/test/pipelines/sample.html
@@ -1,0 +1,377 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Caterpillar - Transform Your Data Pipelines</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            overflow-x: hidden;
+        }
+
+        .container {
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            padding: 2rem;
+            position: relative;
+        }
+
+        .caterpillar-icon {
+            font-size: 4rem;
+            margin-bottom: 1rem;
+            animation: crawl 3s ease-in-out infinite;
+        }
+
+        @keyframes crawl {
+
+            0%,
+            100% {
+                transform: translateX(0) rotate(0deg);
+            }
+
+            25% {
+                transform: translateX(10px) rotate(5deg);
+            }
+
+            75% {
+                transform: translateX(-10px) rotate(-5deg);
+            }
+        }
+
+        .title {
+            font-size: 4rem;
+            font-weight: 700;
+            background: linear-gradient(45deg, #fff, #f0f8ff, #e6f3ff);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            text-align: center;
+            margin-bottom: 1rem;
+            animation: glow 2s ease-in-out infinite alternate;
+        }
+
+        @keyframes glow {
+            from {
+                text-shadow: 0 0 20px rgba(255, 255, 255, 0.5);
+            }
+
+            to {
+                text-shadow: 0 0 30px rgba(255, 255, 255, 0.8), 0 0 40px rgba(255, 255, 255, 0.6);
+            }
+        }
+
+        .subtitle {
+            font-size: 1.5rem;
+            font-weight: 300;
+            text-align: center;
+            margin-bottom: 2rem;
+            opacity: 0.9;
+            animation: fadeInUp 1s ease-out 0.5s both;
+        }
+
+        @keyframes fadeInUp {
+            from {
+                opacity: 0;
+                transform: translateY(30px);
+            }
+
+            to {
+                opacity: 0.9;
+                transform: translateY(0);
+            }
+        }
+
+        .description {
+            max-width: 800px;
+            text-align: center;
+            font-size: 1.1rem;
+            line-height: 1.6;
+            margin-bottom: 3rem;
+            animation: fadeInUp 1s ease-out 1s both;
+        }
+
+        .features {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 2rem;
+            max-width: 1000px;
+            width: 100%;
+            margin-bottom: 3rem;
+        }
+
+        .feature-card {
+            background: rgba(255, 255, 255, 0.1);
+            backdrop-filter: blur(10px);
+            border-radius: 15px;
+            padding: 2rem;
+            text-align: center;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+            animation: fadeInUp 1s ease-out calc(1.5s + var(--delay)) both;
+        }
+
+        .feature-card:hover {
+            transform: translateY(-10px);
+            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+        }
+
+        .feature-card:nth-child(1) {
+            --delay: 0s;
+        }
+
+        .feature-card:nth-child(2) {
+            --delay: 0.2s;
+        }
+
+        .feature-card:nth-child(3) {
+            --delay: 0.4s;
+        }
+
+        .feature-icon {
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+            display: block;
+        }
+
+        .feature-title {
+            font-size: 1.3rem;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+        }
+
+        .feature-description {
+            font-size: 0.95rem;
+            opacity: 0.8;
+        }
+
+        .cta-section {
+            text-align: center;
+            animation: fadeInUp 1s ease-out 2.5s both;
+        }
+
+        .cta-button {
+            display: inline-block;
+            padding: 15px 30px;
+            background: linear-gradient(45deg, #ff6b6b, #ee5a24);
+            color: white;
+            text-decoration: none;
+            border-radius: 50px;
+            font-weight: 600;
+            font-size: 1.1rem;
+            transition: all 0.3s ease;
+            box-shadow: 0 10px 30px rgba(238, 90, 36, 0.4);
+            margin: 0 10px 10px 0;
+        }
+
+        .cta-button:hover {
+            transform: translateY(-3px);
+            box-shadow: 0 15px 40px rgba(238, 90, 36, 0.6);
+        }
+
+        .secondary-button {
+            background: transparent;
+            border: 2px solid rgba(255, 255, 255, 0.8);
+            box-shadow: none;
+        }
+
+        .secondary-button:hover {
+            background: rgba(255, 255, 255, 0.1);
+            box-shadow: 0 10px 30px rgba(255, 255, 255, 0.2);
+        }
+
+        .floating-elements {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            pointer-events: none;
+            overflow: hidden;
+        }
+
+        .floating-element {
+            position: absolute;
+            opacity: 0.1;
+            animation: float 6s ease-in-out infinite;
+        }
+
+        .floating-element:nth-child(1) {
+            top: 10%;
+            left: 10%;
+            animation-delay: 0s;
+        }
+
+        .floating-element:nth-child(2) {
+            top: 20%;
+            right: 10%;
+            animation-delay: 2s;
+        }
+
+        .floating-element:nth-child(3) {
+            bottom: 20%;
+            left: 20%;
+            animation-delay: 4s;
+        }
+
+        @keyframes float {
+
+            0%,
+            100% {
+                transform: translateY(0) rotate(0deg);
+            }
+
+            50% {
+                transform: translateY(-20px) rotate(180deg);
+            }
+        }
+
+        @media (max-width: 768px) {
+            .title {
+                font-size: 2.5rem;
+            }
+
+            .subtitle {
+                font-size: 1.2rem;
+            }
+
+            .features {
+                grid-template-columns: 1fr;
+            }
+
+            .cta-button {
+                display: block;
+                margin: 10px auto;
+                width: fit-content;
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <div class="floating-elements">
+        <div class="floating-element">🐛</div>
+        <div class="floating-element">⚙️</div>
+        <div class="floating-element">🔄</div>
+    </div>
+
+    <div class="container">
+        <div class="caterpillar-icon">🐛</div>
+        <h1 class="title">Caterpillar</h1>
+        <p class="subtitle">Transform Your Data Pipelines with Ease</p>
+
+        <div class="description">
+            <p>Caterpillar is a powerful, flexible data pipeline processing tool that transforms your data workflows
+                from simple caterpillars into beautiful, efficient butterflies. Built with Go for performance and
+                reliability, it handles complex data transformations, file operations, and integrations seamlessly.</p>
+        </div>
+
+        <div class="features">
+            <div class="feature-card">
+                <span class="feature-icon">🚀</span>
+                <h3 class="feature-title">High Performance</h3>
+                <p class="feature-description">Built with Go for lightning-fast data processing and minimal resource
+                    consumption.</p>
+            </div>
+
+            <div class="feature-card">
+                <span class="feature-icon">🔗</span>
+                <h3 class="feature-title">Flexible Pipelines</h3>
+                <p class="feature-description">Create complex data workflows with modular tasks including file
+                    operations, HTTP requests, and data transformations.</p>
+            </div>
+
+            <div class="feature-card">
+                <span class="feature-icon">☁️</span>
+                <h3 class="feature-title">Cloud Ready</h3>
+                <p class="feature-description">Seamless integration with AWS services including S3, SQS, and Parameter
+                    Store with glob pattern support.</p>
+            </div>
+        </div>
+
+        <div class="cta-section">
+            <a href="https://github.com/patterninc/caterpillar" class="cta-button">Get Started</a>
+            <a href="#" class="cta-button secondary-button">Learn More</a>
+        </div>
+    </div>
+
+    <script>
+        // Add some interactive elements
+        document.addEventListener('DOMContentLoaded', function () {
+            // Animate feature cards on scroll
+            const cards = document.querySelectorAll('.feature-card');
+
+            const observer = new IntersectionObserver((entries) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        entry.target.style.transform = 'translateY(0)';
+                        entry.target.style.opacity = '1';
+                    }
+                });
+            });
+
+            cards.forEach(card => {
+                observer.observe(card);
+            });
+
+            // Add click effect to buttons
+            document.querySelectorAll('.cta-button').forEach(button => {
+                button.addEventListener('click', function (e) {
+                    // Create ripple effect
+                    const ripple = document.createElement('div');
+                    const rect = this.getBoundingClientRect();
+                    const size = Math.max(rect.width, rect.height);
+                    const x = e.clientX - rect.left - size / 2;
+                    const y = e.clientY - rect.top - size / 2;
+
+                    ripple.style.cssText = `
+                        position: absolute;
+                        border-radius: 50%;
+                        background: rgba(255, 255, 255, 0.6);
+                        transform: scale(0);
+                        animation: ripple 0.6s linear;
+                        width: ${size}px;
+                        height: ${size}px;
+                        left: ${x}px;
+                        top: ${y}px;
+                        pointer-events: none;
+                    `;
+
+                    this.style.position = 'relative';
+                    this.style.overflow = 'hidden';
+                    this.appendChild(ripple);
+
+                    setTimeout(() => {
+                        ripple.remove();
+                    }, 600);
+                });
+            });
+        });
+
+        // Add CSS for ripple animation
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes ripple {
+                to {
+                    transform: scale(2);
+                    opacity: 0;
+                }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+
+</html>

--- a/test/pipelines/xpath.yaml
+++ b/test/pipelines/xpath.yaml
@@ -1,0 +1,14 @@
+tasks:
+  - id: read_html
+    type: file
+    path: test/pipelines/sample.html
+  - id: extract_data
+    type: xpath
+    container: "//div[@class='feature-card']"
+    fields:
+      title: "./h3"
+      description: "./p"
+      icon: "./span"
+  - id: echo
+    type: echo
+    only_data: true

--- a/test/pipelines/xpath_with_index.yaml
+++ b/test/pipelines/xpath_with_index.yaml
@@ -1,0 +1,17 @@
+tasks:
+  - id: read_html
+    type: file
+    path: test/pipelines/sample.html
+  - id: extract_data
+    type: xpath
+    container: "//div[@class='feature-card']"
+    fields:
+      title: "./h3"
+      description: "./p"
+      icon: "./span"
+  - id: add_index
+    type: jq
+    path: '. + {index: {{ context "node_index" }}}'
+  - id: echo
+    type: echo
+    only_data: true


### PR DESCRIPTION
This PR adds a context key `node_index` to the output records of the Xpath task. Node index is the order in which the node matched and were processed by the xpath task.
- helps with tracking which container element the data was extracted from
- useful for maintaining order or grouping related data