### PR TITLE
fix: context passing through the compress task to downstream tasks

### DIFF
--- a/internal/pkg/pipeline/task/compress/compress.go
+++ b/internal/pkg/pipeline/task/compress/compress.go
@@ -2,7 +2,6 @@ package compress
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 
@@ -54,7 +53,6 @@ func (c *core) Run(input <-chan *record.Record, output chan<- *record.Record) (e
 		return task.ErrNilInput
 	}
 
-	ctx := context.Background()
 
 	for {
 		r, ok := c.GetRecord(input)
@@ -85,7 +83,7 @@ func (c *core) Run(input <-chan *record.Record, output chan<- *record.Record) (e
 		}
 
 		if output != nil {
-			c.SendData(ctx, transformedData, output)
+			c.SendData(r.Context, transformedData, output)
 		}
 	}
 


### PR DESCRIPTION
### Description

- This change addresses a bug in the compress task where the Record Context was not being propagated to the output

```
tasks:
  - name: read_data
    type: file
    path: input/data.json

  # 1. Set a context variable
  - name: set_context
    type: jq
    path: "."
    context:
      request_id: ".id"

  # 2. Compress data (Context was previously lost here)
  - name: compress_data
    type: compress
    format: gzip
    action: compress

  # 3. Decompress data
  - name: decompress_data
    type: compress
    format: gzip
    action: decompress

  # 4. output path relies on the context variable persisting
  - name: write_result
    type: file
    path: "output/result_{{ context "request_id" }}.txt" 
```

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
  <!--- Go Style Guide https://github.com/uber-go/guide/blob/master/style.md -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
