### PR TITLE
close producer before closing delivery channel to prevent panic

### DIFF
--- a/internal/pkg/pipeline/task/kafka/kafka.go
+++ b/internal/pkg/pipeline/task/kafka/kafka.go
@@ -174,6 +174,9 @@ func (k *kafka) write(input <-chan *record.Record) error {
 	// Always flush so enqueued messages get delivery reports and the goroutine exits cleanly.
 	timeout := time.Duration(k.Timeout)
 	remaining := p.Flush(int(timeout.Milliseconds()))
+	
+	// Close the producer BEFORE closing deliveryCh:
+	p.Close()
 	close(deliveryCh)
 	wg.Wait()
 


### PR DESCRIPTION
  ## Description                                                                                                                                                                                                         
   
  Fix `panic: send on closed channel` in the Kafka write task.                                                                                                                              
  production pipelines after the Confluent migration in #61.
                                                                                                                                                                                                                     
  The producer's per-message delivery channel was being closed before the producer                                                                                                                                   
  itself, so librdkafka's internal poller goroutine could try to forward a final
  delivery report onto an already-closed channel — which is an unrecoverable panic.                                                                                                                                  
  With `task_concurrency: 200`, a single producer hitting the race took down the
  whole pipeline.                                                                                                                                                                                                    
  
#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
  <!--- Go Style Guide https://github.com/uber-go/guide/blob/master/style.md -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
