### PR TITLE
FEAT: Add max_records to kafka task

### DIFF
--- a/internal/pkg/pipeline/task/kafka/README.md
+++ b/internal/pkg/pipeline/task/kafka/README.md
@@ -6,7 +6,7 @@ The `kafka` task reads from or writes to Apache Kafka topics.
 
 The Kafka task operates in two modes depending on whether an input channel is provided:
 - **Write mode** (with input channel): receives records from the input channel and enqueues them to the Kafka topic with the Confluent producer. `batch_flush_interval` maps to the producer's `linger.ms`, and the task flushes pending deliveries before exiting.
-- **Read mode** (no input channel): polls messages from the Kafka topic and sends them to the output channel. The reader's polling is controlled by the configured `timeout` and `retry_limit` behavior (see below). Optionally, `end_after` sets a wall-clock deadline that stops the reader regardless of traffic.
+- **Read mode** (no input channel): polls messages from the Kafka topic and sends them to the output channel. The reader's polling is controlled by the configured `timeout` and `retry_limit` behavior (see below). Optionally, `end_after` sets a wall-clock deadline that stops the reader regardless of traffic, and `max_records` stops the reader after a fixed number of messages have been forwarded downstream.
 
 The task automatically determines its mode based on the presence of input/output channels.
 
@@ -31,6 +31,7 @@ There are two read modes, controlled by whether `group_id` is set:
 | `batch_flush_interval` | duration string | `2s` | Producer linger interval (`linger.ms`) for batching queued writes |
 | `retry_limit` | int | `5` | Read retry threshold; reading stops when consecutive retryable errors or timeouts exceed this value |
 | `end_after` | duration string | - | Wall-clock deadline for read mode. When set, the reader stops cleanly after this duration regardless of message traffic. Worst-case overshoot is one `timeout` window. |
+| `max_records` | int | `0` (unlimited) | Read-mode cap on records forwarded downstream. The reader stops cleanly once this many messages have been sent. In group mode, offsets up to the last forwarded record are committed on shutdown. |
 | `group_id` | string | - | Consumer group id. If omitted, standalone mode is used (reads from beginning, no offset commits). |
 | `auto_offset_reset` | string | `latest` | Group-mode reset policy when no committed offset exists or the stored offset is out of range. `latest` skips to the tail; `earliest` reads from the beginning of the available log. Ignored in standalone mode. |
 | `server_auth_type` | string | `none` | `none` or `tls` — server certificate verification mode |
@@ -175,6 +176,20 @@ tasks:
     timeout: 10s
 ```
 
+### Stop after a fixed number of records
+```yaml
+tasks:
+  - name: read_first_100
+    type: kafka
+    bootstrap_server: kafka.local:9092
+    topic: input-topic
+    group_id: my-consumer-group
+    max_records: 100
+    timeout: 5s
+```
+
+> Combine `max_records` with `end_after` to stop on whichever condition is hit first (e.g. "up to 100 records or 30s, whichever comes first").
+
 ### Group consumer reading from the beginning on first run
 ```yaml
 tasks:
@@ -191,6 +206,7 @@ tasks:
  - **Group consumer mode** resumes from committed offsets. `auto_offset_reset` fires only if the group has no prior committed offsets or the stored offset is out of range (e.g., aged out by retention). To re-read from the beginning, reset group offsets via `kafka-consumer-groups.sh --reset-offsets --to-earliest`.
  - **Out-of-range stored offset:** librdkafka logs a `%4|OFFSET ... offset reset` warning when this happens. It's informational — the consumer self-recovers to the position implied by `auto_offset_reset`. The warning persists across restarts until a successful read commits a new valid offset (or until you manually reset the group offsets at the broker).
  - **`end_after`** sets a wall-clock read deadline distinct from `retry_limit` (which is idle-based). Use `end_after` when you want a guaranteed stop time even on a busy topic. Worst-case shutdown latency is one `timeout` window because in-flight `ReadMessage` polls cannot be canceled mid-flight.
+ - **`max_records`** is count-based and independent of `end_after`/`retry_limit`. The counter increments after each record is forwarded downstream, so the cap is exact for delivered records. If the topic has fewer than `max_records` available, the reader keeps polling until `retry_limit` or `end_after` fires.
  - **Group commits** use Kafka auto-commit every 5000ms. Auto offset store is disabled, so offsets are stored only after a message is sent downstream.
  - **Read isolation** is set to `read_committed` for both standalone and group consumers — this is the consumer-side complement to `idempotent: true` on the producer and ensures consumers never read uncommitted or aborted messages.
  - The init broker probe always uses the 15s default timeout regardless of the configured `timeout` to allow for SCRAM+TLS handshake round trips.

--- a/internal/pkg/pipeline/task/kafka/README.md
+++ b/internal/pkg/pipeline/task/kafka/README.md
@@ -31,7 +31,7 @@ There are two read modes, controlled by whether `group_id` is set:
 | `batch_flush_interval` | duration string | `2s` | Producer linger interval (`linger.ms`) for batching queued writes |
 | `retry_limit` | int | `5` | Read retry threshold; reading stops when consecutive retryable errors or timeouts exceed this value |
 | `end_after` | duration string | - | Wall-clock deadline for read mode. When set, the reader stops cleanly after this duration regardless of message traffic. Worst-case overshoot is one `timeout` window. |
-| `max_records` | int | `0` (unlimited) | Read-mode cap on records forwarded downstream. The reader stops cleanly once this many messages have been sent. In group mode, offsets up to the last forwarded record are committed on shutdown. |
+| `max_records` | int | `0` (unlimited) | Read-mode cap on records forwarded downstream. The reader stops cleanly once this many messages have been sent. In group mode, offsets up to the last forwarded record are committed on shutdown. Must be `>= 0`; negative values are rejected at validation. |
 | `group_id` | string | - | Consumer group id. If omitted, standalone mode is used (reads from beginning, no offset commits). |
 | `auto_offset_reset` | string | `latest` | Group-mode reset policy when no committed offset exists or the stored offset is out of range. `latest` skips to the tail; `earliest` reads from the beginning of the available log. Ignored in standalone mode. |
 | `server_auth_type` | string | `none` | `none` or `tls` — server certificate verification mode |

--- a/internal/pkg/pipeline/task/kafka/kafka.go
+++ b/internal/pkg/pipeline/task/kafka/kafka.go
@@ -48,6 +48,7 @@ type kafka struct {
 	GroupID            string               `yaml:"group_id,omitempty" json:"group_id,omitempty"`                         // the consumer group id (optional)
 	AutoOffsetReset    string               `yaml:"auto_offset_reset,omitempty" json:"auto_offset_reset,omitempty" validate:"omitempty,oneof=earliest latest"` // group-mode reset policy when stored offset is out of range; "earliest" (default) or "latest"
 	BatchSize          int                  `yaml:"batch_size,omitempty" json:"batch_size,omitempty"`                     // max messages per producer batch (maps to batch.num.messages); defaults to 100
+	MaxRecords         int                  `yaml:"max_records,omitempty" json:"max_records,omitempty"`                   // stop reading after this many records (0 = unlimited)
 	RetryLimit         *int                 `yaml:"retry_limit,omitempty" json:"retry_limit,omitempty"`                   // number of retries for read errors
 	Idempotent         bool                 `yaml:"idempotent,omitempty" json:"idempotent,omitempty"`                     // enable idempotent producer
 	Format             string               `yaml:"format,omitempty" json:"format,omitempty"`                             // message format: "json" (default) or "avro"
@@ -246,6 +247,7 @@ func (k *kafka) read(ctx context.Context, output chan<- *record.Record) error {
 
 	timeout := time.Duration(k.Timeout)
 	retriesNumber := 0
+	recordsRead := 0
 	for {
 		select {
 		case <-ctx.Done():
@@ -287,6 +289,12 @@ func (k *kafka) read(ctx context.Context, output chan<- *record.Record) error {
 				fmt.Printf("warning: failed to store offset for topic %s partition %d: %v\n",
 					k.Topic, msg.TopicPartition.Partition, err)
 			}
+		}
+
+		recordsRead++
+		if k.MaxRecords > 0 && recordsRead >= k.MaxRecords {
+			fmt.Printf("kafka max_records (%d) reached for topic %s, stopping reader\n", k.MaxRecords, k.Topic)
+			return nil
 		}
 	}
 }

--- a/internal/pkg/pipeline/task/kafka/kafka.go
+++ b/internal/pkg/pipeline/task/kafka/kafka.go
@@ -48,7 +48,7 @@ type kafka struct {
 	GroupID            string               `yaml:"group_id,omitempty" json:"group_id,omitempty"`                                                              // the consumer group id (optional)
 	AutoOffsetReset    string               `yaml:"auto_offset_reset,omitempty" json:"auto_offset_reset,omitempty" validate:"omitempty,oneof=earliest latest"` // group-mode reset policy when stored offset is out of range; "earliest" (default) or "latest"
 	BatchSize          int                  `yaml:"batch_size,omitempty" json:"batch_size,omitempty"`                                                          // max messages per producer batch (maps to batch.num.messages); defaults to 100
-	MaxRecords         int                  `yaml:"max_records,omitempty" json:"max_records,omitempty"`                                                        // stop reading after this many records (0 = unlimited)
+	MaxRecords         int                  `yaml:"max_records,omitempty" json:"max_records,omitempty" validate:"omitempty,gte=0"`                             // stop reading after this many records (0 = unlimited); negative values are rejected at validation
 	RetryLimit         *int                 `yaml:"retry_limit,omitempty" json:"retry_limit,omitempty"`                                                        // number of retries for read errors
 	Idempotent         bool                 `yaml:"idempotent,omitempty" json:"idempotent,omitempty"`                                                          // enable idempotent producer
 	Format             string               `yaml:"format,omitempty" json:"format,omitempty"`                                                                  // message format: "json" (default) or "avro"

--- a/test/pipelines/kafka_read_max_records.yaml
+++ b/test/pipelines/kafka_read_max_records.yaml
@@ -1,0 +1,19 @@
+tasks:
+  - name: kafka_read
+    type: kafka
+    bootstrap_server: '{{ secret "/kafka/server" }}:9094'
+    topic: test-caterpillar-topic
+    user_auth_type: scram
+    username: test-caterpillar
+    password: {{ secret "/kafka/test-caterpillar/secret" }}
+    server_auth_type: tls
+    timeout: 2s
+    max_records: 10            # stop after 10 records have been forwarded downstream
+    end_after: 30s             # safety net: stop after 30s even if max_records is not reached
+    auto_offset_reset: latest
+    cert: |
+      {{ indent 6 (secret "/kafka/ca-cert") }}
+
+  - name: echo_results
+    type: echo
+    only_data: true


### PR DESCRIPTION
## Summary
- Adds a `max_records` field to the kafka read task that stops the reader after N records have been forwarded downstream.
- Independent from `end_after` (wall-clock) and `retry_limit` (idle-based); the three can be combined.
- In group consumer mode, offsets up to the last forwarded record are committed on shutdown via the deferred `c.Close()`.
- README updated with the new field, an example, and a behavior note; new test pipeline `test/pipelines/kafka_read_max_records.yaml` added.

## Test plan
- [ ] Run `test/pipelines/kafka_read_max_records.yaml` against a populated topic and verify exactly 10 records are emitted before the reader stops.
- [ ] Re-run the same pipeline in group-consumer mode and confirm offsets for the consumed records are committed (subsequent runs resume past them).
- [ ] Run against an empty/low-traffic topic and confirm the reader still exits cleanly via `end_after` / `retry_limit` when `max_records` cannot be reached.
- [ ] `go build ./...` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)