### PR TITLE
FIX: Fail file task on a missing S3/local file when fail_on_error is set

### DIFF
--- a/internal/pkg/pipeline/task/file/local.go
+++ b/internal/pkg/pipeline/task/file/local.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"fmt"
 	"github.com/bmatcuk/doublestar"
 	"github.com/patterninc/caterpillar/internal/pkg/pipeline/record"
 )
@@ -42,8 +43,16 @@ func (r *localReader) parse(glob string) ([]string, error) {
 		return nil, err
 	}
 
+	if len(paths) == 0 && !containsGlob(glob) {
+		return nil, fmt.Errorf("file does not exist: %s", glob)
+	}
+
 	return paths, nil
 
+}
+
+func containsGlob(glob string) bool {
+	return strings.ContainsAny(glob, `*?[{`)
 }
 
 func writeLocalFile(f *file, rec *record.Record, reader io.Reader) error {

--- a/internal/pkg/pipeline/task/file/local.go
+++ b/internal/pkg/pipeline/task/file/local.go
@@ -43,16 +43,12 @@ func (r *localReader) parse(glob string) ([]string, error) {
 		return nil, err
 	}
 
-	if len(paths) == 0 && !containsGlob(glob) {
-		return nil, fmt.Errorf("file does not exist: %s", glob)
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no files found at %s", glob)
 	}
 
 	return paths, nil
 
-}
-
-func containsGlob(glob string) bool {
-	return strings.ContainsAny(glob, `*?[{`)
 }
 
 func writeLocalFile(f *file, rec *record.Record, reader io.Reader) error {

--- a/internal/pkg/pipeline/task/file/s3.go
+++ b/internal/pkg/pipeline/task/file/s3.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"strings"
 	"unicode/utf16"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -72,10 +71,6 @@ func (r *s3Reader) parse(glob string) ([]string, error) {
 		return nil, err
 	}
 
-	if len(objects) == 0 && !containsGlob(glob) {
-		return nil, fmt.Errorf("file does not exist: s3://%s/%s", bucket, glob)
-	}
-
 	paths := make([]string, 0, len(objects))
 	for _, object := range objects {
 		path := fmt.Sprintf("s3://%s/%s", bucket, *object.Key)
@@ -84,10 +79,6 @@ func (r *s3Reader) parse(glob string) ([]string, error) {
 
 	return paths, nil
 
-}
-
-func containsGlob(p string) bool {
-	return strings.ContainsAny(p, `*?[{`)
 }
 
 func writeS3File(f *file, rec *record.Record, reader io.Reader) error {

--- a/internal/pkg/pipeline/task/file/s3.go
+++ b/internal/pkg/pipeline/task/file/s3.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"strings"
 	"unicode/utf16"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -71,6 +72,10 @@ func (r *s3Reader) parse(glob string) ([]string, error) {
 		return nil, err
 	}
 
+	if len(objects) == 0 && !containsGlob(glob) {
+		return nil, fmt.Errorf("file does not exist: s3://%s/%s", bucket, glob)
+	}
+
 	paths := make([]string, 0, len(objects))
 	for _, object := range objects {
 		path := fmt.Sprintf("s3://%s/%s", bucket, *object.Key)
@@ -79,6 +84,10 @@ func (r *s3Reader) parse(glob string) ([]string, error) {
 
 	return paths, nil
 
+}
+
+func containsGlob(p string) bool {
+	return strings.ContainsAny(p, `*?[{`)
 }
 
 func writeS3File(f *file, rec *record.Record, reader io.Reader) error {

--- a/internal/pkg/pipeline/task/file/s3_client/client.go
+++ b/internal/pkg/pipeline/task/file/s3_client/client.go
@@ -61,16 +61,12 @@ func (c *Client) GetObjects(ctx context.Context, bucketName, pattern string) ([]
 
 	}
 
-	if len(matchingObjects) == 0 && !containsGlob(pattern) {
-		return nil, fmt.Errorf("file does not exist: s3://%s/%s", bucketName, pattern)
+	if len(matchingObjects) == 0 {
+		return nil, fmt.Errorf("no files found at s3://%s/%s", bucketName, pattern)
 	}
 
 	return matchingObjects, nil
 
-}
-
-func containsGlob(pattern string) bool {
-	return strings.ContainsAny(pattern, `*?[{`)
 }
 
 func ParseURI(path string) (bucket string, key string, err error) {

--- a/internal/pkg/pipeline/task/file/s3_client/client.go
+++ b/internal/pkg/pipeline/task/file/s3_client/client.go
@@ -61,8 +61,16 @@ func (c *Client) GetObjects(ctx context.Context, bucketName, pattern string) ([]
 
 	}
 
+	if len(matchingObjects) == 0 && !containsGlob(pattern) {
+		return nil, fmt.Errorf("file does not exist: s3://%s/%s", bucketName, pattern)
+	}
+
 	return matchingObjects, nil
 
+}
+
+func containsGlob(pattern string) bool {
+	return strings.ContainsAny(pattern, `*?[{`)
 }
 
 func ParseURI(path string) (bucket string, key string, err error) {


### PR DESCRIPTION
### Description

The `file` task silently succeeded when reading a concrete S3/local path that does
not exist, so a missing file never tripped `fail_on_error`. This fixes it: a
named (non-glob) S3/local path that matches no object now returns an error.

#### Investigation (why it was marked successful for s3)

Reading from S3 is two steps:

- **Discovery** - `s3Reader.parse` -> `GetObjects` -> `ListObjectsV2` + `doublestar.Match`. This returns an **empty slice with a nil error** when nothing matches.
- **Fetch** - `s3Reader.read` -> `GetObject`, which *would* error (`NoSuchKey`) on a missing key - but it only runs for paths discovery already returned.

For a missing file, discovery returns zero paths, `readFile`'s loop runs zero
times and returns `nil`, and the task is marked succeeded. `fail_on_error` only
acts on a returned error, so with no error there was nothing for it to do.

#### Fix

In `parse`, after listing: if the path matched zero objects, return error. The error
propagates up; the existing pipeline logs it always and fails the task only when
`fail_on_error=true`.

#### Behavior: before vs. after

| Path | `fail_on_error` | Before | After |
|------|------|--------|-------|
| Concrete file, missing | `true` | Succeeds silently (the bug) | Fail and Error (no files found) |
| Concrete file, missing | `false` | Succeeds silently | Succeeds, now logs the error (still completes) |
| Concrete file, exists | any | Reads it | Reads it (unchanged) |
| Glob, no match | any | Empty success | Error (no files found) |
| Glob, matches files | any | Reads matches | Reads matches (unchanged) |

#### Testing

Verified end-to-end against with S3 Sandbox

Sandbox S3 details:
<img width="823" height="589" alt="S3Bucket" src="https://github.com/user-attachments/assets/e9d11dc0-085d-4966-94aa-d233a87d80cc" />


Test run before fix (4/5 cases pass):
<img width="561" height="819" alt="BeforeFix" src="https://github.com/user-attachments/assets/9d11f618-ad6e-4aad-9470-36b92b0367ad" />


Test run after fix (5/5 cases pass):
<img width="691" height="849" alt="AfterFix" src="https://github.com/user-attachments/assets/bb1c13b2-804f-453a-92fe-dbf0ec7483ba" />

Similar checks have been added to local file parsing



#### Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
