### PR TITLE
FEAT: Add client_rack field to kafka task

### DIFF
--- a/internal/pkg/pipeline/task/kafka/README.md
+++ b/internal/pkg/pipeline/task/kafka/README.md
@@ -34,6 +34,7 @@ There are two read modes, controlled by whether `group_id` is set:
 | `max_records` | int | `0` (unlimited) | Read-mode cap on records forwarded downstream. The reader stops cleanly once this many messages have been sent. In group mode, offsets up to the last forwarded record are committed on shutdown. Must be `>= 0`; negative values are rejected at validation. |
 | `group_id` | string | - | Consumer group id. If omitted, standalone mode is used (reads from beginning, no offset commits). |
 | `auto_offset_reset` | string | `latest` | Group-mode reset policy when no committed offset exists or the stored offset is out of range. `latest` skips to the tail; `earliest` reads from the beginning of the available log. Ignored in standalone mode. |
+| `client_rack` | string | - | Read-mode rack id, set as librdkafka `client.rack`. Lets the consumer use Kafka's rack-aware features to cut cross-AZ data transfers. Applies to standalone and group consumer modes; ignored for producers. |
 | `server_auth_type` | string | `none` | `none` or `tls` — server certificate verification mode |
 | `cert` | string | - | CA certificate PEM/CRT content used when `server_auth_type: tls` (alternatively use `cert_path`) |
 | `cert_path` | string | - | Path to CA certificate (PEM/CRT) |
@@ -107,6 +108,18 @@ tasks:
     bootstrap_server: kafka.local:9092
     topic: input-topic
     group_id: my-consumer-group
+    timeout: 25s
+```
+
+### Rack-aware consumer
+```yaml
+tasks:
+  - name: read_in_zone
+    type: kafka
+    bootstrap_server: kafka.local:9092
+    topic: input-topic
+    group_id: my-consumer-group
+    client_rack: us-west-2a   # match the broker.rack of broker closest to consumer's location
     timeout: 25s
 ```
 

--- a/internal/pkg/pipeline/task/kafka/README.md
+++ b/internal/pkg/pipeline/task/kafka/README.md
@@ -119,7 +119,7 @@ tasks:
     bootstrap_server: kafka.local:9092
     topic: input-topic
     group_id: my-consumer-group
-    client_rack: us-west-2a   # match the broker.rack of broker closest to consumer's location
+    client_rack: us-west-2a   # match the broker.rack of the broker closest to the consumer's location
     timeout: 25s
 ```
 

--- a/internal/pkg/pipeline/task/kafka/kafka.go
+++ b/internal/pkg/pipeline/task/kafka/kafka.go
@@ -46,6 +46,7 @@ type kafka struct {
 	Timeout            duration.Duration    `yaml:"timeout,omitempty" json:"timeout,omitempty"`                                                                // connection, read, write, commit timeout
 	BatchFlushInterval duration.Duration    `yaml:"batch_flush_interval,omitempty" json:"batch_flush_interval,omitempty"`                                      // interval to flush incomplete batches
 	GroupID            string               `yaml:"group_id,omitempty" json:"group_id,omitempty"`                                                              // the consumer group id (optional)
+	ClientRack         string               `yaml:"client_rack,omitempty" json:"client_rack,omitempty"`                                                        // rack id for enabling rack-aware features
 	AutoOffsetReset    string               `yaml:"auto_offset_reset,omitempty" json:"auto_offset_reset,omitempty" validate:"omitempty,oneof=earliest latest"` // group-mode reset policy when stored offset is out of range; "earliest" (default) or "latest"
 	BatchSize          int                  `yaml:"batch_size,omitempty" json:"batch_size,omitempty"`                                                          // max messages per producer batch (maps to batch.num.messages); defaults to 100
 	MaxRecords         int                  `yaml:"max_records,omitempty" json:"max_records,omitempty" validate:"omitempty,gte=0"`                             // stop reading after this many records (0 = unlimited); negative values are rejected at validation
@@ -406,6 +407,10 @@ func (k *kafka) buildConsumerConfig() (*ckafka.ConfigMap, error) {
 	_ = cfg.SetKey("isolation.level", "read_committed")
 	_ = cfg.SetKey("group.id", k.GroupID)
 
+	if k.ClientRack != "" {
+		_ = cfg.SetKey("client.rack", k.ClientRack)
+	}
+
 	return cfg, nil
 }
 
@@ -420,6 +425,10 @@ func (k *kafka) buildStandaloneConsumerConfig() (*ckafka.ConfigMap, error) {
 	_ = cfg.SetKey("enable.auto.commit", false)
 	_ = cfg.SetKey("auto.offset.reset", "earliest")
 	_ = cfg.SetKey("isolation.level", "read_committed")
+
+	if k.ClientRack != "" {
+		_ = cfg.SetKey("client.rack", k.ClientRack)
+	}
 
 	return cfg, nil
 }


### PR DESCRIPTION
### Description

Adds an optional `client_rack` field to the kafka task that sets librdkafka's
`client.rack` on the consumer. This lets a consumer take advantage of Kafka's
rack-aware features like fetch-from-follower (KIP-392) and rack-aware partition
assignment (KIP-881), so it reads from a replica in its own availability zone
instead of the (possibly cross-AZ) leader, reducing inter-AZ data transfer cost.

The value is passed through to both the group consumer and standalone consumer
configs, and is omitted entirely when unset.

Note: this is the client-side requirement only. The benefit is realized when the
brokers are configured with `broker.rack` (and, for fetch-from-follower, a
rack-aware `replica.selector.class` such as `RackAwareReplicaSelector`).

### Test
My tests were performed locally with 3 brokers (podman containers), with a single partition in a topic called `t392` (replication set to 3, leader on broker-1)
#### Before
Without client_rack (consumer fetches from the leader broker (broker - 1))
Example yaml used:
```tasks:
  - name: kafka_read
    type: kafka
    bootstrap_server: localhost:19092
    topic: t392
    user_auth_type: none
    timeout: 2s
    end_after: 8s
  - name: echo_results
    type: echo
    only_data: true
```
<img width="1441" height="654" alt="rack_test_before" src="https://github.com/user-attachments/assets/a78c6408-a76c-4767-8d4d-a5274aa99b01" />

#### After
With client_rack set to `rack-c`(same as broker -3) and `replica.selector.class` set to `RackAwareReplicaSelector` for brokers (consumer sends the initial request to leader broker (broker - 1), subsequent fetches migrate to broker - 3)
Example yaml used:
```tasks:
  - name: kafka_read
    type: kafka
    bootstrap_server: localhost:19092
    topic: t392
    user_auth_type: none
    timeout: 2s
    end_after: 8s
    client_rack: rack-c
  - name: echo_results
    type: echo
    only_data: true
```
<img width="1432" height="712" alt="rack_test_after" src="https://github.com/user-attachments/assets/4c683f36-bc8c-4199-b4bd-2ea4cb44c924" />


#### Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
