### PR TITLE
feat(http task): let next_page write record context

### DIFF
--- a/internal/pkg/pipeline/task/http/README.md
+++ b/internal/pkg/pipeline/task/http/README.md
@@ -22,6 +22,83 @@ The HTTP task outputs the response body as-is (maintains backward compatibility)
 
 For example, if the HTTP response includes a `Content-Type` header, it will be available as `{{ context "http-header-Content-Type" }}` in subsequent tasks. Note that HTTP header names are case-sensitive when used as context keys. Go's HTTP library canonicalizes header names (for example, `content-type` becomes `Content-Type`), so you must use the canonical form when accessing headers via context (for example, `http-header-Content-Type`, not `http-header-content-type`).
 
+### Pagination
+
+`next_page` is a JQ expression evaluated after every response. Returning `empty` ends pagination, returning a string sets the next endpoint, and returning an object sets any of `endpoint`, `method`, `body`, `headers`, and `context`. A bare string reuses the current method and headers.
+
+The expression receives two JQ inputs. The first is the response envelope:
+
+| Field | Description |
+|-------|-------------|
+| `.data` | Response body as a string |
+| `.headers` | Response headers |
+
+The second holds the page counter:
+
+| Field | Description |
+|-------|-------------|
+| `.page_id` | 1-indexed number of the page about to be requested |
+
+Because the initial request is page 1, `page_id` is `2` on the first evaluation. It covers APIs that page by number or offset:
+
+```yaml
+next_page: |
+  [inputs] as $input |
+  ($input[0].data | fromjson) as $body |
+  ($input[1].page_id) as $page |
+  if ($body.results | length) == 100 then
+    "https://api.example.com/things?per_page=100&page=" + ($page | tostring)
+  else empty end
+```
+
+`inputs` is a one-shot iterator, so capture it once and index into it. A second `[inputs]` yields an empty list, and the resulting `null` compares as less than every number — which silently turns a bound like `$page <= 50` into an infinite loop.
+
+Piping also rebinds `.`, so `.data | fromjson as $body | ...` leaves `.` as the body string rather than the envelope.
+
+#### Carrying state across pages
+
+`context` writes values onto the record before the next iteration renders its templates. Use it for state the response and the counter can't reconstruct — a cursor, a query the next request must reproduce, a running budget. Values are readable via `{{ context "key" }}` in later iterations and by downstream tasks.
+
+Some APIs scope a page token to the query that issued it, and cap how many items one query can walk, so exhausting a token means re-querying with a new filter and then paging that. The token loop has to reproduce the current filter, not the one the task started with:
+
+```yaml
+next_page: |
+  [inputs] as $input |
+  ($input[0].data | fromjson) as $body |
+  ($body.next_token // "") as $token |
+  ($body.items | length) as $count |
+  ($body.items | .[-1].id // "") as $last_id |
+  "{{ context "current_query" }}" as $query |
+  if $token != "" then
+    { endpoint: ("https://api.example.com/things?" + $query + "&page_token=" + ($token | @uri)) }
+  elif $count >= 100 and $last_id != "" then
+    (($query | sub("&after_id=[^&]*"; "")) + "&after_id=" + ($last_id | @uri)) as $next_query |
+    {
+      endpoint: ("https://api.example.com/things?" + $next_query),
+      context: { current_query: $next_query }
+    }
+  else empty end
+```
+
+The token branch replays `current_query` as-is; the branch that moves the filter rewrites and republishes it, so new tokens are replayed against the query that issued them.
+
+These are values, not expressions — the task-level `context:` block takes JQ that caterpillar evaluates for you, but `next_page` is itself the JQ. A string is stored verbatim, so `context: { cursor: ".data | fromjson | .next" }` stores that text instead of the extracted value. Keep values scalar; objects render as inline JSON.
+
+#### Reading a context key vs writing one
+
+Writing creates the key — `context: { anything: $value }` works whether or not it existed.
+
+Reading requires the key to be set already. Templates are substituted as plain text before JQ parses the expression, so even an unreachable branch counts:
+
+```yaml
+# fails: context keys were not set: cursor
+next_page: 'if false then "{{ context "cursor" }}" else empty end'
+```
+
+Seed anything the expression reads in the upstream task's `context` block, since on page 1 the read happens before any write.
+
+There is no cap on iterations: an expression that never returns `empty` loops forever. Make sure every branch advances toward a terminal condition, since a cursor that repeats or a boundary that stops moving will not stop on its own.
+
 ## Configuration Fields
 
 | Field | Type | Default | Description |
@@ -38,7 +115,7 @@ For example, if the HTTP response includes a `Content-Type` header, it will be a
 | `expected_statuses` | string | `200` | Comma-separated list of expected HTTP status codes |
 | `oauth` | object | - | OAuth configuration (see OAuth section) |
 | `proxy` | object | - | Proxy configuration |
-| `next_page` | string/object | - | JQ expression to extract next page URL (string) or pagination config (object with`endpoint`, `method`, `body`, `headers`) |
+| `next_page` | string/object | - | JQ expression to extract next page URL (string) or pagination config (object with `endpoint`, `method`, `body`, `headers`, `context`) — see [Pagination](#pagination) |
 | `context` | map[string]string | - | JQ expressions to extract values from the response and store in record context |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
 

--- a/internal/pkg/pipeline/task/http/http.go
+++ b/internal/pkg/pipeline/task/http/http.go
@@ -265,6 +265,19 @@ func (h *httpCore) processItem(rc *record.Record, output chan<- *record.Record) 
 					}
 				}
 			}
+
+			// Applied before the next iteration renders its templates, so pagination
+			// can carry state a single response doesn't contain. JSON-encoded to
+			// match task.Base, so `{{ context }}` renders the same either way.
+			if contextVal, ok := nextPageMap["context"].(map[string]interface{}); ok {
+				for name, value := range contextVal {
+					encoded, err := json.Marshal(value)
+					if err != nil {
+						return fmt.Errorf("cannot set context value %s: %s", name, err)
+					}
+					rc.SetContextValue(name, string(encoded))
+				}
+			}
 		} else {
 			break
 		}

--- a/test/pipelines/next_page_context_test.yaml
+++ b/test/pipelines/next_page_context_test.yaml
@@ -1,0 +1,51 @@
+# Pagination state carried in record context: each page republishes the query for
+# the next one. page_id cannot substitute here -- the offset advances by the item
+# count actually received, not by a fixed page size.
+tasks:
+  - name: seed_source
+    type: file
+    path: test/pipelines/names.txt
+
+  - name: build_first_request
+    type: jq
+    path: |
+      {
+        endpoint: "https://jsonplaceholder.typicode.com/posts?_limit=3&_start=0"
+      }
+    # next_page reads current_query, so it has to exist before the first render.
+    context:
+      current_query: '"_limit=3&_start=0"'
+
+  - name: fetch_pages
+    type: http
+    method: GET
+    next_page: |
+      [inputs] as $input |
+      ($input[0].data | fromjson) as $body |
+      ($body | length) as $count |
+      "{{ context "current_query" }}" as $query |
+      ($query | capture("_start=(?<offset>[0-9]+)") | .offset | tonumber) as $offset |
+      ($offset + $count) as $next_offset |
+      if $count >= 3 and $next_offset < 9 then
+        (($query | sub("&_start=[0-9]+"; "")) + "&_start=" + ($next_offset | tostring)) as $next_query |
+        {
+          endpoint: ("https://jsonplaceholder.typicode.com/posts?" + $next_query),
+          context: {
+            current_query: $next_query
+          }
+        }
+      else empty end
+
+  # Expect three records, each reporting the query that fetched it:
+  #   _start=0 -> ids 1,2,3    _start=3 -> ids 4,5,6    _start=6 -> ids 7,8,9
+  - name: report_carried_state
+    type: jq
+    path: |
+      {
+        query_used: "{{ context "current_query" }}",
+        ids: map(.id)
+      }
+
+  - name: echo
+    type: echo
+    only_data: true


### PR DESCRIPTION
## Problem

`next_page` could read record context but never write it. Every value it saw was fixed at the moment the upstream task emitted the record, so pagination could not carry state that a single response does not contain.

This blocks any API where pages are nested inside something that also moves — e.g. a page token scoped to the exact query that issued it, plus a cap on how many items one query can walk. Exhausting a token means re-querying with a new filter and then paging that, and the token loop has to reproduce the *current* filter. With a frozen query it reproduces the original one, and the API rejects the replayed token.

## Change

A `context` map in the object returned by `next_page` is now applied to the record, before the next iteration renders its templates. 13 lines in `processItem`.

```yaml
next_page: |
  [inputs] as $input |
  ($input[0].data | fromjson) as $body |
  "{{ context "current_query" }}" as $query |
  if ($body.next_token // "") != "" then
    { endpoint: ("…?" + $query + "&page_token=" + ($body.next_token | @uri)) }
  else
    (($query | sub("&after_id=[^&]*"; "")) + "&after_id=" + $last_id) as $next_query |
    { endpoint: ("…?" + $next_query), context: { current_query: $next_query } }
  end
```

Values are JSON-encoded to match how `task.Base` sets context (`task.go:138-143`), so `{{ context "key" }}` renders identically regardless of which one wrote the key. Writes go through the existing `record.SetContextValue`.

## Compatibility

Opt-in and unreachable for every pipeline as it stands — I scanned all 793 YAMLs in `data-airflow`, and **zero** `next_page` blocks currently return a `context` key. Nothing else about the task changes.

## Verification

`test/pipelines/next_page_context_test.yaml` walks three pages where each one republishes the offset for the next:

```
{"ids":[1,2,3],"query_used":"_limit=3&_start=0"}
{"ids":[4,5,6],"query_used":"_limit=3&_start=3"}
{"ids":[7,8,9],"query_used":"_limit=3&_start=6"}
```

Each page reads back what the previous one wrote, and the value differs per emitted record downstream. `page_id` cannot substitute — the offset advances by the item count actually received.

During development this was also covered by Go tests against a mock that rejected a page token replayed under a different query, with a negative control proving the frozen-query form fails there. Those were dropped in favour of the test pipeline, so **this behaviour has no automated regression guard.**

## Docs

New Pagination section in the task README, which also writes down things that were previously undocumented or easy to get wrong:

- Both JQ inputs, including the page counter — `[inputs][1].page_id`, 1-indexed on the page about to be requested, so `2` on the first evaluation. Used by ~30 pipelines, documented nowhere.
- `inputs` is a one-shot iterator. A second `[inputs]` yields an empty list, and jq's `null <= 50` is **true**, so a page bound written that way becomes an infinite loop. This hung a test while I was writing it.
- The `context` map takes values, not expressions — a string is stored verbatim, so `context: { cursor: ".data | fromjson | .next" }` silently stores that text.
- Writing a key creates it; reading one requires it to exist already, **including in a branch that never executes**, since template substitution is textual and happens before JQ parses the expression.

## Follow-up, not in this PR

A `next_page` render failure returns from `processItem`, which under the default `fail_on_error: false` is only printed (`pipeline.go:243-249`). The run reports success having emitted page 1 alone. This PR makes it slightly easier to trip, because reading a carried key means depending on an upstream seed. Worth making such a failure fatal regardless of `fail_on_error`, so truncated pagination cannot pass as success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)