### PR TITLE
fix(jq): return errors from custom functions instead of panicking

### DIFF
--- a/internal/pkg/jq/crypto.go
+++ b/internal/pkg/jq/crypto.go
@@ -104,7 +104,7 @@ func cryptoHashOptions() []gojq.CompilerOption {
 		opt := gojq.WithFunction(name, 0, 0, func(raw any, _ []any) any {
 			str, ok := raw.(string)
 			if !ok {
-				panic(fmt.Errorf("expected string for %s, got %T", name, raw))
+				return fmt.Errorf("expected string for %s, got %T", name, raw)
 			}
 			return fn(str)
 		})
@@ -133,15 +133,15 @@ func signOptions() []gojq.CompilerOption {
 			// args[0] is the data to sign, args[1] is the private key
 			data, ok := args[0].(string)
 			if !ok {
-				panic(fmt.Errorf("expected string for data for sign  %s, got %T", name, args[0]))
+				return fmt.Errorf("expected string for data for sign  %s, got %T", name, args[0])
 			}
 			key, ok := args[1].(string)
 			if !ok {
-				panic(fmt.Errorf("expected string for key for sign %s, got %T", name, args[1]))
+				return fmt.Errorf("expected string for key for sign %s, got %T", name, args[1])
 			}
 			result, err := fn(data, []byte(key))
 			if err != nil {
-				panic(err)
+				return err
 			}
 			return result
 		})
@@ -157,17 +157,17 @@ func messageAuthOptions() []gojq.CompilerOption {
 		opt := gojq.WithFunction(name, 2, 3, func(_ any, args []any) any {
 			data, ok := args[0].(string)
 			if !ok {
-				panic(fmt.Errorf("expected string for data %s, got %T", name, args[0]))
+				return fmt.Errorf("expected string for data %s, got %T", name, args[0])
 			}
 			key, ok := args[1].(string)
 			if !ok {
-				panic(fmt.Errorf("expected string for key %s, got %T", name, args[0]))
+				return fmt.Errorf("expected string for key %s, got %T", name, args[0])
 			}
 			var pref = []byte{}
 			if len(args) == 3 {
 				p, ok := args[2].(string)
 				if !ok {
-					panic(fmt.Errorf("expected string for pref %s, got %T", name, args[2]))
+					return fmt.Errorf("expected string for pref %s, got %T", name, args[2])
 				}
 				pref = []byte(p)
 			}

--- a/internal/pkg/jq/jq.go
+++ b/internal/pkg/jq/jq.go
@@ -82,8 +82,10 @@ func (q *Query) Execute(document []byte, inputs ...any) (any, error) {
 			break
 		}
 
-		if _, isError := v.(error); isError {
-			return nil, nil
+		// Custom functions signal failure by returning an error rather than panicking,
+		// since gojq does not recover panics raised inside them.
+		if err, isError := v.(error); isError {
+			return nil, err
 		}
 
 		result = append(result, v)

--- a/internal/pkg/jq/translate.go
+++ b/internal/pkg/jq/translate.go
@@ -2,6 +2,7 @@ package jq
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -55,31 +56,31 @@ func translateText(_ any, args []any) any {
 	ctx := context.Background()
 	txClient, err := new(ctx)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	if len(args) < 3 {
-		panic("translate requires 3 arguments: text, source language, target language")
+		return fmt.Errorf("translate requires 3 arguments: text, source language, target language")
 	}
 
 	textStr, ok := args[0].(string)
 	if !ok {
-		panic("invalid text type")
+		return fmt.Errorf("expected string for text for translate, got %T", args[0])
 	}
 
 	sourceLang, ok := args[1].(string)
 	if !ok {
-		panic("invalid source language type")
+		return fmt.Errorf("expected string for source language for translate, got %T", args[1])
 	}
 
 	targetLang, ok := args[2].(string)
 	if !ok {
-		panic("invalid target language type")
+		return fmt.Errorf("expected string for target language for translate, got %T", args[2])
 	}
 
 	translatedText, err := txClient.TranslateText(ctx, textStr, sourceLang, targetLang)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	return translatedText

--- a/internal/pkg/pipeline/task/jq/README.md
+++ b/internal/pkg/pipeline/task/jq/README.md
@@ -105,6 +105,29 @@ tasks:
 
 In addition to standard JQ functions, Caterpillar provides custom functions to extend JQ capabilities:
 
+### Error handling
+
+Custom functions report bad input as a JQ error. With `fail_on_error: false` (the default) the
+offending record is logged and skipped and the task carries on; with `fail_on_error: true` the error
+stops the task and fails the pipeline.
+
+Because these are ordinary JQ errors, they can be caught and turned into data. Bind the result of a
+single call rather than repeating the call in both branches, since some of these functions are
+expensive:
+
+```yaml
+tasks:
+  - name: hash_or_report
+    type: jq
+    path: |
+      . as $record
+      | (try ($record.payload | sha256) catch "error: \(.)") as $outcome
+      | {
+          "id": $record.id,
+          "outcome": $outcome
+        }
+```
+
 ### translate
 
 Translates text using AWS Translate service.

--- a/internal/pkg/pipeline/task/jq/jq.go
+++ b/internal/pkg/pipeline/task/jq/jq.go
@@ -38,7 +38,13 @@ func (j *jq) Run(input <-chan *record.Record, output chan<- *record.Record) (err
 			// Execute the JQ query
 			items, err := query.Execute(r.Data)
 			if err != nil {
-				return err
+				// One malformed record must not truncate the stream, so a query failure
+				// only stops the task when the pipeline asked to fail on error.
+				if j.GetFailOnError() {
+					return err
+				}
+				fmt.Printf("error in %s: skipping record %d: %s\n", j.GetName(), r.ID, err)
+				continue
 			}
 			if items == nil {
 				continue


### PR DESCRIPTION
### Description

Custom jq functions raised panics on bad input. gojq does not recover panics thrown inside custom functions, so a malformed argument anywhere in a jq expression took down the whole process with a stack trace instead of surfacing as a task error.

This converts all 17 panic sites to returned errors — 11 in `crypto.go` (`md5`/`sha256`/`sha512`, `rsa_*` signing, `hmac_*`) and 6 in `translate.go`.

Returning errors alone was not enough. `Query.Execute` was discarding error values and returning `nil, nil`, so failures would have become silently dropped records, which is worse than a crash for a data pipeline. `Execute` now propagates the error.

Because that propagation affects every jq caller, the jq task consults `fail_on_error` so behaviour matches what the root README already documents:

```
# fail_on_error unset (default) — logged, record skipped, task continues
error in hash_each: skipping record 2: expected string for sha256, got float64
error in hash_each: skipping record 3: expected string for sha256, got map[string]interface {}
{"digest":"b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9","id":"valid_string"}

# fail_on_error: true — task fails, pipeline fails, exit 1
pipeline: pipeline failed with errors:
Task 'hash_each' failed with error: expected string for sha256, got float64
```

A side benefit: because these are now ordinary jq errors rather than panics, they can be caught inside a pipeline and turned into data, which was previously impossible.

```
{"id":"valid_string","outcome":"b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"}
{"id":"invalid_number","outcome":"error: expected string for sha256, got float64"}
```

#### Worth a closer look

Consulting `fail_on_error` inside a task is new to this repo — every other task simply returns and lets `runTaskConcurrently` decide. I deviated because a bare `return err` would newly kill the task mid-stream and drop every remaining record, where today a bad record is skipped. Happy to align with the existing pattern if reviewers prefer consistency over stream resilience.

#### Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

Verified by running `test/pipelines/hash_test.yaml`, `uuid_test.yaml` and `hello_name.yaml` (which exercises the context-query path through `Execute`) with no regressions, plus `go test ./internal/pkg/pipeline/`. Both error paths above were confirmed with throwaway pipelines. The `bcrypt` PR stacked on top of this one adds a committed test pipeline that asserts every rejection path.
