### PR TITLE
feat(jq): add bcrypt function with caller-supplied salt (DATA-9790)

### DIFF
--- a/internal/pkg/jq/crypto.go
+++ b/internal/pkg/jq/crypto.go
@@ -13,14 +13,45 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/itchyny/gojq"
+	"golang.org/x/crypto/blowfish"
 )
 
 type hashFunc func(string) string
 type messageAuthenticationFunc func(data string, key []byte, pref []byte) string
 type signFunc func(data string, privateKey []byte) (string, error)
+
+const (
+	bcryptRawSaltLength     = 16
+	bcryptEncodedSaltLength = 22
+	bcryptChecksumBytes     = 23
+	bcryptMaxDataLength     = 72
+	bcryptDefaultVersion    = "2a"
+	bcryptDefaultCost       = 4
+	bcryptMinCost           = 4
+	bcryptMaxCost           = 31
+)
+
+// bcrypt orders its base64 alphabet differently from standard base64, so the two
+// encodings are not interchangeable.
+var bcryptEncoding = base64.NewEncoding("./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789").WithPadding(base64.NoPadding)
+
+// IV for bcrypt's 64 Blowfish encryption rounds.
+var bcryptMagicCipherData = []byte("OrpheanBeholderScryDoubt")
+
+// 2x is excluded deliberately: it exists to reproduce crypt_blowfish's 8-bit
+// sign-extension bug, which Go does not implement, so output labelled 2x would
+// disagree with a real 2x implementation for non-ASCII input.
+var bcryptSupportedVersions = map[string]struct{}{
+	"2":  {},
+	"2a": {},
+	"2b": {},
+	"2y": {},
+}
 
 // Supported hash algorithms
 var hashFuncs = map[string]hashFunc{
@@ -176,6 +207,140 @@ func messageAuthOptions() []gojq.CompilerOption {
 		options = append(options, opt)
 	}
 	return options
+}
+
+// Returns gojq.CompilerOption for bcrypt hashing against a caller-supplied salt.
+//
+// x/crypto/bcrypt exposes only GenerateFromPassword, which always draws its own random
+// salt, so any scheme deriving a value from bcrypt(data, fixed_salt) is unreachable
+// through it. Usage: "data" | bcrypt($salt), where the salt's modular-crypt prefix
+// selects the version and cost.
+func bcryptOptions() []gojq.CompilerOption {
+
+	opt := gojq.WithFunction("bcrypt", 1, 1, func(raw any, args []any) any {
+
+		data, ok := raw.(string)
+		if !ok {
+			return fmt.Errorf("expected string for data for bcrypt, got %T", raw)
+		}
+
+		salt, ok := args[0].(string)
+		if !ok {
+			return fmt.Errorf("expected string for salt for bcrypt, got %T", args[0])
+		}
+
+		encodedSalt, version, cost, err := parseBcryptSalt(salt)
+		if err != nil {
+			return err
+		}
+
+		result, err := bcryptHash(data, version, cost, encodedSalt)
+		if err != nil {
+			return err
+		}
+
+		return result
+
+	})
+
+	return []gojq.CompilerOption{opt}
+
+}
+
+// Accepts a bare 22-character salt or a modular-crypt string ($2a$04$<salt>), returning
+// the salt plus whichever version and cost the prefix carried. A full hash is also a
+// valid argument - its salt is the leading 22 characters of the trailing field, the same
+// way CompareHashAndPassword recovers one.
+func parseBcryptSalt(salt string) (string, string, int, error) {
+
+	if !strings.HasPrefix(salt, "$") {
+		return salt, bcryptDefaultVersion, bcryptDefaultCost, nil
+	}
+
+	fields := strings.Split(strings.TrimPrefix(salt, "$"), "$")
+	if len(fields) < 3 {
+		return "", "", 0, fmt.Errorf("malformed bcrypt salt: want $version$cost$salt")
+	}
+
+	cost, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return "", "", 0, fmt.Errorf("malformed bcrypt cost %q: %w", fields[1], err)
+	}
+
+	return fields[2], fields[0], cost, nil
+
+}
+
+func bcryptHash(data, version string, cost int, encodedSalt string) (string, error) {
+
+	if _, ok := bcryptSupportedVersions[version]; !ok {
+		return "", fmt.Errorf("unsupported bcrypt version %q, want 2, 2a, 2b or 2y", version)
+	}
+
+	if cost < bcryptMinCost || cost > bcryptMaxCost {
+		return "", fmt.Errorf("bcrypt cost %d outside allowed range %d..%d", cost, bcryptMinCost, bcryptMaxCost)
+	}
+
+	// bcrypt reads only the first 72 bytes. Rejecting rather than truncating stops two
+	// different payloads from yielding one hash.
+	if len(data) > bcryptMaxDataLength {
+		return "", fmt.Errorf("bcrypt data length %d exceeds %d bytes", len(data), bcryptMaxDataLength)
+	}
+
+	if len(encodedSalt) < bcryptEncodedSaltLength {
+		return "", fmt.Errorf("bcrypt salt must be at least %d characters, got %d", bcryptEncodedSaltLength, len(encodedSalt))
+	}
+	encodedSalt = encodedSalt[:bcryptEncodedSaltLength]
+
+	salt, err := bcryptEncoding.DecodeString(encodedSalt)
+	if err != nil {
+		return "", fmt.Errorf("bcrypt salt is not valid bcrypt base64: %w", err)
+	}
+
+	if len(salt) != bcryptRawSaltLength {
+		return "", fmt.Errorf("bcrypt salt must decode to %d bytes, got %d", bcryptRawSaltLength, len(salt))
+	}
+
+	cipher, err := expensiveBlowfishSetup([]byte(data), uint32(cost), salt)
+	if err != nil {
+		return "", err
+	}
+
+	block := make([]byte, len(bcryptMagicCipherData))
+	copy(block, bcryptMagicCipherData)
+
+	for i := 0; i < len(block); i += 8 {
+		for j := 0; j < 64; j++ {
+			cipher.Encrypt(block[i:i+8], block[i:i+8])
+		}
+	}
+
+	// Only 23 of the 24 encrypted bytes are encoded, matching the C implementations.
+	// Encoding all 24 yields a checksum no other bcrypt agrees with.
+	return fmt.Sprintf("$%s$%02d$%s%s", version, cost, encodedSalt, bcryptEncoding.EncodeToString(block[:bcryptChecksumBytes])), nil
+
+}
+
+// Runs bcrypt's cost-driven key schedule. The Blowfish calls are the same exported ones
+// x/crypto/bcrypt uses internally, so no cryptographic primitive is reimplemented here.
+func expensiveBlowfishSetup(key []byte, cost uint32, salt []byte) (*blowfish.Cipher, error) {
+
+	// C implementations expand the key including its terminating NUL. Dropping this byte
+	// produces output that matches no other bcrypt.
+	ckey := append(key[:len(key):len(key)], 0)
+
+	cipher, err := blowfish.NewSaltedCipher(ckey, salt)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, rounds := uint64(0), uint64(1)<<cost; i < rounds; i++ {
+		blowfish.ExpandKey(ckey, cipher)
+		blowfish.ExpandKey(salt, cipher)
+	}
+
+	return cipher, nil
+
 }
 
 // there are two case one we directly pass the PEM encoded private key

--- a/internal/pkg/jq/jq.go
+++ b/internal/pkg/jq/jq.go
@@ -110,6 +110,7 @@ func customFunctionsOptions() []gojq.CompilerOption {
 	options = append(options, signOptions()...)
 	options = append(options, uuidOptions()...)
 	options = append(options, messageAuthOptions()...)
+	options = append(options, bcryptOptions()...)
 	options = append(options, shuffleOptions()...)
 	options = append(options, sleepOptions()...)
 	options = append(options, translateOption()...)

--- a/internal/pkg/pipeline/task/jq/README.md
+++ b/internal/pkg/pipeline/task/jq/README.md
@@ -128,6 +128,59 @@ tasks:
         }
 ```
 
+### bcrypt
+
+Hashes the piped value with bcrypt using a salt you supply. Go's standard bcrypt always generates
+its own random salt, so this function exists for schemes that derive a value from a *fixed* salt —
+for example an API that signs requests with `bcrypt(client_id + "_" + timestamp)` using the client
+secret as the salt.
+
+**Signature:** `data | bcrypt(salt)`
+
+**Parameters:**
+- `data` (string, piped): The value to hash. Maximum 72 bytes — bcrypt reads no further, so longer input is rejected rather than silently truncated.
+- `salt` (string): Either a bare 22-character salt or a full modular-crypt string such as `$2a$04$abcdefghijklmnopqrstuu`. A complete hash is also accepted, in which case its salt is reused.
+
+To select a version or cost, supply the salt in modular-crypt form — `$2b$10$abcdefghijklmnopqrstuu`
+uses version `2b` at cost 10. A bare salt defaults to version `2a` at cost 4. Supported versions are
+`2`, `2a`, `2b` and `2y`; `2x` is not supported. Cost ranges from 4 to 31.
+
+The salt uses bcrypt's own base64 alphabet (`./A-Za-z0-9`), which orders characters differently from
+standard base64, so a salt produced by `@base64` will not round-trip.
+
+**Returns:** A modular-crypt string, `$<version>$<cost>$<salt><checksum>`
+
+**Example:**
+```yaml
+tasks:
+  - name: sign_token_request
+    type: jq
+    path: |
+      {
+        "signature": (
+          (.client_id + "_" + (.timestamp | tostring))
+          | bcrypt("{{ env \"CLIENT_SECRET\" }}")
+        )
+      }
+```
+
+When the salt comes from the record rather than a literal, bind it first. Inside `bcrypt(...)` the
+input is the piped string, so a bare `.salt` would be evaluated against that string instead of the
+enclosing object:
+
+```yaml
+tasks:
+  - name: sign_with_per_record_salt
+    type: jq
+    path: |
+      . as $record | {
+        "signature": ($record.payload | bcrypt($record.salt))
+      }
+```
+
+**Note:** The default cost of 4 is the lowest bcrypt permits. It suits reproducing a signature, but
+choose a substantially higher cost when hashing anything that needs to resist offline attack.
+
 ### translate
 
 Translates text using AWS Translate service.
@@ -158,10 +211,13 @@ tasks:
 
 ## Sample Pipelines
 
+- `test/pipelines/bcrypt_test.yaml` - bcrypt hashing against known-answer vectors
 - `test/pipelines/context_test.yaml` - JQ with context variables
 - `test/pipelines/convert_industries.yaml` - Data transformation with JQ
+- `test/pipelines/hash_test.yaml` - Hashing with JQ
 - `test/pipelines/html2json.yaml` - HTML to JSON conversion
 - `test/pipelines/translate_test.yaml` - Text translation with JQ
+- `test/pipelines/uuid_test.yaml` - UUID generation with JQ
 
 ## Use Cases
 

--- a/test/pipelines/bcrypt_cases.json
+++ b/test/pipelines/bcrypt_cases.json
@@ -1,0 +1,134 @@
+[
+  {
+    "name": "bare_salt_defaults_to_2a_cost_4",
+    "data": "allmine",
+    "salt": "XajjQvNhvvRt5GSeFk1xFe",
+    "expected": "$2a$04$XajjQvNhvvRt5GSeFk1xFeFSjbRlNk/Ta1yxtAEbNtK1N.ZPZVHUu"
+  },
+  {
+    "name": "upstream_known_answer_cost_10",
+    "data": "allmine",
+    "salt": "$2a$10$XajjQvNhvvRt5GSeFk1xFe",
+    "expected": "$2a$10$XajjQvNhvvRt5GSeFk1xFeyqRrsxkhBkUiQeg0dt.wU1qD4aFDcga"
+  },
+  {
+    "name": "cost_read_from_salt_prefix",
+    "data": "allmine",
+    "salt": "$2a$06$XajjQvNhvvRt5GSeFk1xFe",
+    "expected": "$2a$06$XajjQvNhvvRt5GSeFk1xFenXDhAWTtiuYVFqohMZ8DFcwdkTSrQ9m"
+  },
+  {
+    "name": "version_2b",
+    "data": "allmine",
+    "salt": "$2b$04$XajjQvNhvvRt5GSeFk1xFe",
+    "expected": "$2b$04$XajjQvNhvvRt5GSeFk1xFeFSjbRlNk/Ta1yxtAEbNtK1N.ZPZVHUu"
+  },
+  {
+    "name": "version_2y",
+    "data": "allmine",
+    "salt": "$2y$04$XajjQvNhvvRt5GSeFk1xFe",
+    "expected": "$2y$04$XajjQvNhvvRt5GSeFk1xFeFSjbRlNk/Ta1yxtAEbNtK1N.ZPZVHUu"
+  },
+  {
+    "name": "full_hash_reused_as_salt",
+    "data": "allmine",
+    "salt": "$2a$10$XajjQvNhvvRt5GSeFk1xFeyqRrsxkhBkUiQeg0dt.wU1qD4aFDcga",
+    "expected": "$2a$10$XajjQvNhvvRt5GSeFk1xFeyqRrsxkhBkUiQeg0dt.wU1qD4aFDcga"
+  },
+  {
+    "name": "single_byte_of_data",
+    "data": "k",
+    "salt": "XajjQvNhvvRt5GSeFk1xFe",
+    "expected": "$2a$04$XajjQvNhvvRt5GSeFk1xFepbFmn5qB6E32eDZVF4nGTBzvpodiua2"
+  },
+  {
+    "name": "data_at_72_byte_maximum",
+    "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "salt": "XajjQvNhvvRt5GSeFk1xFe",
+    "expected": "$2a$04$XajjQvNhvvRt5GSeFk1xFeEJbavgjNvL/jG9AE6IkyS6AkyJy/ySS"
+  },
+  {
+    "name": "non_ascii_data",
+    "data": "pästel-Ω",
+    "salt": "XajjQvNhvvRt5GSeFk1xFe",
+    "expected": "$2a$04$XajjQvNhvvRt5GSeFk1xFe730/5CcL3wKWG7T7.STsMSIB3tRROg."
+  },
+  {
+    "name": "salt_of_all_dots",
+    "data": "allmine",
+    "salt": "......................",
+    "expected": "$2a$04$......................COqHO4FmNPvlXsQuH6eZpm4fmQBEyxG"
+  },
+  {
+    "name": "request_signature_shape",
+    "data": "test-client-id_1699999999999",
+    "salt": "$2a$04$abcdefghijklmnopqrstuu",
+    "expected": "$2a$04$abcdefghijklmnopqrstuuH1UXnaO7ONwppVwdkk87sINyprJzJI."
+  },
+  {
+    "name": "salt_shorter_than_22_chars",
+    "data": "allmine",
+    "salt": "tooshort",
+    "expected_error": "bcrypt salt must be at least 22 characters, got 8"
+  },
+  {
+    "name": "salt_outside_bcrypt_alphabet",
+    "data": "allmine",
+    "salt": "XajjQvNhvvRt5GSeFk1xF!",
+    "expected_error": "bcrypt salt is not valid bcrypt base64: illegal base64 data at input byte 21"
+  },
+  {
+    "name": "unsupported_version",
+    "data": "allmine",
+    "salt": "$3a$04$XajjQvNhvvRt5GSeFk1xFe",
+    "expected_error": "unsupported bcrypt version \"3a\", want 2, 2a, 2b or 2y"
+  },
+  {
+    "name": "version_2x_rejected_deliberately",
+    "data": "allmine",
+    "salt": "$2x$04$XajjQvNhvvRt5GSeFk1xFe",
+    "expected_error": "unsupported bcrypt version \"2x\", want 2, 2a, 2b or 2y"
+  },
+  {
+    "name": "cost_below_minimum",
+    "data": "allmine",
+    "salt": "$2a$03$XajjQvNhvvRt5GSeFk1xFe",
+    "expected_error": "bcrypt cost 3 outside allowed range 4..31"
+  },
+  {
+    "name": "cost_above_maximum",
+    "data": "allmine",
+    "salt": "$2a$32$XajjQvNhvvRt5GSeFk1xFe",
+    "expected_error": "bcrypt cost 32 outside allowed range 4..31"
+  },
+  {
+    "name": "data_over_72_bytes",
+    "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "salt": "XajjQvNhvvRt5GSeFk1xFe",
+    "expected_error": "bcrypt data length 73 exceeds 72 bytes"
+  },
+  {
+    "name": "malformed_salt_prefix",
+    "data": "allmine",
+    "salt": "$2a$XajjQvNhvvRt5GSeFk1xFe",
+    "expected_error": "malformed bcrypt salt: want $version$cost$salt"
+  },
+  {
+    "name": "non_numeric_cost_in_prefix",
+    "data": "allmine",
+    "salt": "$2a$xx$XajjQvNhvvRt5GSeFk1xFe",
+    "expected_error": "malformed bcrypt cost \"xx\": strconv.Atoi: parsing \"xx\": invalid syntax"
+  },
+  {
+    "name": "non_string_data",
+    "data": 123,
+    "salt": "XajjQvNhvvRt5GSeFk1xFe",
+    "expected_error": "expected string for data for bcrypt, got float64"
+  },
+  {
+    "name": "non_string_salt",
+    "data": "allmine",
+    "salt": 123,
+    "expected_error": "expected string for salt for bcrypt, got float64"
+  }
+]

--- a/test/pipelines/bcrypt_test.yaml
+++ b/test/pipelines/bcrypt_test.yaml
@@ -1,0 +1,34 @@
+tasks:
+  - name: read_bcrypt_cases
+    type: file
+    path: test/pipelines/bcrypt_cases.json
+  - name: hash_and_compare
+    type: jq
+    explode: true
+    # Each case carries either an expected hash or an expected error message. The salt is
+    # bound to $case first: inside bcrypt(...) the input is the piped data string, so a
+    # bare .salt would not resolve there.
+    path: |
+      [
+        .[]
+        | . as $case
+        | (try ($case.data | bcrypt($case.salt)) catch tostring) as $actual
+        | ($case.expected // $case.expected_error) as $expected
+        | {
+            "name": $case.name,
+            "expected": $expected,
+            "actual": $actual,
+            "match": ($actual == $expected)
+          }
+      ] as $results
+      | $results + [
+          {
+            "name": "summary",
+            "passed": ([$results[] | select(.match)] | length),
+            "total": ($results | length),
+            "all_passed": (([$results[] | select(.match | not)] | length) == 0)
+          }
+        ]
+  - name: echo
+    type: echo
+    only_data: true


### PR DESCRIPTION
### Description

Resolves DATA-9790.

`x/crypto/bcrypt` exposes only `GenerateFromPassword`, which always draws its own random salt. That leaves no way to compute `bcrypt(data, fixed_salt)`, so pipelines that need to reproduce a third-party request signature had no path forward.

This adds a `bcrypt` jq function taking a caller-supplied salt:

```yaml
path: |
  {
    "signature": (
      (.client_id + "_" + (.timestamp | tostring))
      | bcrypt("{{ env \"CLIENT_SECRET\" }}")
    )
  }
```

No cryptographic primitive is reimplemented — the Blowfish key schedule delegates to the same exported `blowfish` calls that `x/crypto/bcrypt` uses internally.

#### API shape

The signature is `data | bcrypt(salt)` only. Version and cost travel in the salt's modular-crypt prefix (`$2b$10$<22 chars>`) rather than as separate arguments.

I initially built this with optional `$version` and `$cost` arguments, then cut them: the modular-crypt salt already carries both, so the extra arities were a second way to express the same thing and required a precedence rule for when the two disagreed. Widening the arity later is a one-line backward-compatible change; narrowing it after pipelines depend on it is not.

A bare salt defaults to `$2a$` at cost 4. Supported versions are `2`, `2a`, `2b`, `2y`. `2x` is deliberately rejected, since it exists to reproduce crypt_blowfish's sign-extension bug that Go does not implement, so output labelled `2x` would disagree with a real `2x` implementation for non-ASCII input.

#### Testing

`test/pipelines/bcrypt_test.yaml` checks 22 cases and reports a summary record:

```
{"all_passed":true,"name":"summary","passed":22,"total":22}
```

The expected hashes were **not** generated by this code. They were produced with an independent bcrypt implementation (Python `bcrypt` 5.0) so the fixture is a genuine oracle rather than a snapshot of our own output. Coverage includes the known-answer vector published in `x/crypto/bcrypt`'s own test suite, cost taken from the salt prefix, each supported version, a full hash reused as a salt, single-byte and 72-byte data, non-ASCII data, and all 11 rejection paths.

Asserting the rejection paths from a pipeline is only possible because of the error handling in the PR below — `try/catch` cannot catch a panic.

#### One nuance worth flagging

A 22-character bcrypt salt encodes exactly 128 bits, so the final character's low 4 bits must be zero. Stricter implementations reject salts that violate this (Python rejects `...uv`), while Go's base64 decoder ignores those bits and `x/crypto/bcrypt` does the same. This implementation is lenient, matching Go and the C implementations. Docs and fixtures use canonical salts, but a hash built on a non-canonical salt will not reproduce under a stricter implementation.

#### Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
