### PR TITLE
feat: per-record oauth credentials and SSM parameter lookup

### DIFF
--- a/internal/pkg/config/context.go
+++ b/internal/pkg/config/context.go
@@ -23,19 +23,6 @@ func setContextPlaceholder(key string) (string, error) {
 	return fmt.Sprintf(contextPlaceholderString, key), nil
 }
 
-// HasUnresolvedContextPlaceholders reports whether s still contains a context
-// placeholder that was not substituted. Callers that invoke String.Get(nil) should
-// check this to fail fast rather than passing a literal placeholder downstream.
-func HasUnresolvedContextPlaceholders(s string) bool {
-	return contextTemplateRegex.MatchString(s)
-}
-
-// ErrUnresolvedContextPlaceholder names the field and explains that per-record
-// context values require an input record.
-func ErrUnresolvedContextPlaceholder(field string) error {
-	return fmt.Errorf("field %q contains unresolved context placeholder; per-record values require an input record", field)
-}
-
 func evaluateContext(data string, record *record.Record) (string, error) {
 
 	// Find all context template patterns

--- a/internal/pkg/config/context.go
+++ b/internal/pkg/config/context.go
@@ -23,6 +23,19 @@ func setContextPlaceholder(key string) (string, error) {
 	return fmt.Sprintf(contextPlaceholderString, key), nil
 }
 
+// HasUnresolvedContextPlaceholders reports whether s still contains a context
+// placeholder that was not substituted. Callers that invoke String.Get(nil) should
+// check this to fail fast rather than passing a literal placeholder downstream.
+func HasUnresolvedContextPlaceholders(s string) bool {
+	return contextTemplateRegex.MatchString(s)
+}
+
+// ErrUnresolvedContextPlaceholder names the field and explains that per-record
+// context values require an input record.
+func ErrUnresolvedContextPlaceholder(field string) error {
+	return fmt.Errorf("field %q contains unresolved context placeholder; per-record values require an input record", field)
+}
+
 func evaluateContext(data string, record *record.Record) (string, error) {
 
 	// Find all context template patterns

--- a/internal/pkg/pipeline/task/aws/parameter_store/README.md
+++ b/internal/pkg/pipeline/task/aws/parameter_store/README.md
@@ -1,21 +1,30 @@
 # AWS Parameter Store Task
 
-The `aws_parameter_store` task reads from or writes to AWS Systems Manager Parameter Store, enabling secure configuration management and parameter operations.
+The `aws_parameter_store` task writes to or reads from AWS Systems Manager Parameter Store.
 
 ## Function
 
-The AWS Parameter Store task operates in two modes depending on whether an input channel is provided:
+The task operates in two modes, selected by which field is configured:
 
-- **Write mode** (with input channel): Receives records from the input channel and sets parameters in Parameter Store based on the data
-- **Read mode** (no input channel): Retrieves parameters from Parameter Store and sends them to the output channel
+- **Write mode**: Receives records from the input channel and sets parameters in Parameter Store based on the data. Requires `set`.
+- **Lookup mode**: Fetches parameters per record and writes the decrypted values into record context. Requires `lookup`.
+
+`set` and `lookup` are mutually exclusive. The task always requires an input channel.
+
+| Mode | Field | Behaviour |
+|------|-------|-----------|
+| Write | `set` | Sets the `set` parameters from each record, then forwards that record downstream unchanged |
+| Lookup | `lookup` | Fetches parameters whose paths may vary per record, writes values to record context, then forwards the record |
 
 ## Input Channel
 
-In write mode, accepts `*record.Record` objects containing data that can be used to set parameters in Parameter Store.
+Accepts `*record.Record` objects. Lookup paths may reference record context via `{{ context "..." }}`.
 
 ## Output Channel
 
-In read mode, sends `*record.Record` objects containing parameter values from Parameter Store.
+In write mode, each input record is forwarded downstream once, regardless of how many parameters `set` writes.
+
+In lookup mode, each input record is forwarded after its context is populated. `SecureString` values are decrypted.
 
 ## Configuration Fields
 
@@ -23,17 +32,24 @@ In read mode, sends `*record.Record` objects containing parameter values from Pa
 |-------|------|---------|-------------|
 | `name` | string | - | Task name for identification |
 | `type` | string | `aws_parameter_store` | Must be "aws_parameter_store" |
-| `set` | map[string]string | - | Parameters to set using JQ expressions |
-| `get` | map[string]string | - | Parameters to retrieve from Parameter Store |
-| `secure` | bool | `true` | Whether to store parameters as SecureString |
+| `set` | map[string]string | - | Parameters to set, keyed by parameter name, valued by JQ expression |
+| `lookup` | map[string]string | - | Parameters to retrieve per record, keyed by context field name, valued by parameter path |
+| `cache_ttl` | duration | `5m` | How long successful lookups are cached. `0` disables caching. |
+| `on_missing` | string | `error` | Behaviour when a parameter does not exist: `error` stops the task; `skip` logs and drops the record |
+| `secure` | bool | `true` | Whether to store parameters as SecureString (write mode only) |
 | `overwrite` | bool | `true` | Whether to overwrite existing parameters |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
+
+Only successful lookups are cached. Missing parameters are never cached and always follow `on_missing`.
 
 ## Example Configurations
 
 ### Write mode - Set parameters from pipeline data:
 ```yaml
 tasks:
+  - name: source
+    type: file
+    path: credentials.json
   - name: set_config
     type: aws_parameter_store
     set:
@@ -43,22 +59,36 @@ tasks:
     overwrite: true
 ```
 
-### Read mode - Get parameters from Parameter Store:
+### Lookup mode - Fetch per-record credentials into context:
 ```yaml
 tasks:
-  - name: get_config
+  - name: extract_slug
+    type: jq
+    path: .
+    context:
+      slug: .channel_id
+  - name: fetch_credentials
     type: aws_parameter_store
-    get:
-      "api_key": "/prod/api/key"
-      "database_url": "/prod/database/url"
+    lookup:
+      client_email: /caterpillar/kms_google_drive_ingestion/accounts/{{ context "slug" }}/client_email
+      private_key: /caterpillar/kms_google_drive_ingestion/accounts/{{ context "slug" }}/private_key
+    cache_ttl: 5m
+    on_missing: skip
+  - name: call_api
+    type: http
+    endpoint: https://www.googleapis.com/drive/v3/files
+    oauth:
+      version: "2.0"
+      issuer: "{{ context \"client_email\" }}"
+      subject: "{{ context \"client_email\" }}"
+      private_key: "{{ context \"private_key\" }}"
 ```
-
 
 ## Use Cases
 
 - **Configuration management**: Store and retrieve application configuration
 - **Secret management**: Securely store and retrieve sensitive data
 - **Dynamic configuration**: Update parameters based on pipeline data
+- **Multi-tenant credentials**: Resolve per-tenant secrets from SSM at runtime
 - **Environment setup**: Configure different environments with different parameters
 - **Data persistence**: Store pipeline results for later use
-- **Cross-pipeline sharing**: Share data between different pipeline runs

--- a/internal/pkg/pipeline/task/aws/parameter_store/parameter_store.go
+++ b/internal/pkg/pipeline/task/aws/parameter_store/parameter_store.go
@@ -2,30 +2,63 @@ package parameter_store
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 
+	cfg "github.com/patterninc/caterpillar/internal/pkg/config"
+	"github.com/patterninc/caterpillar/internal/pkg/duration"
 	"github.com/patterninc/caterpillar/internal/pkg/jq"
 	"github.com/patterninc/caterpillar/internal/pkg/pipeline/record"
 	"github.com/patterninc/caterpillar/internal/pkg/pipeline/task"
 )
 
+const defaultCacheTTL = 5 * time.Minute
+
+type onMissingBehavior string
+
+const (
+	onMissingError onMissingBehavior = "error"
+	onMissingSkip  onMissingBehavior = "skip"
+)
+
 var (
 	ctx     = context.Background()
 	awsTrue = aws.Bool(true)
+
+	errBothModes      = fmt.Errorf(`set and lookup are mutually exclusive`)
+	errLookupRequired = fmt.Errorf(`lookup must be set when task has an input channel`)
+	errSetRequired    = fmt.Errorf(`set must be set when task has an input channel`)
+	errInputRequired  = fmt.Errorf(`aws_parameter_store requires an input channel`)
 )
+
+type ssmAPI interface {
+	GetParameter(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
+	PutParameter(ctx context.Context, params *ssm.PutParameterInput, optFns ...func(*ssm.Options)) (*ssm.PutParameterOutput, error)
+}
+
+type cacheEntry struct {
+	value     string
+	fetchedAt time.Time
+}
 
 type parameterStore struct {
 	task.Base     `yaml:",inline" json:",inline"`
-	SetParameters map[string]*jq.Query `yaml:"set,omitempty" json:"set,omitempty"`
-	GetParameters map[string]string    `yaml:"get,omitempty" json:"get,omitempty"`
-	Secure        bool                 `yaml:"secure,omitempty" json:"secure,omitempty"`
-	Overwrite     *bool                `yaml:"overwrite,omitempty" json:"overwrite,omitempty"`
-	client        *ssm.Client
+	SetParameters map[string]*jq.Query  `yaml:"set,omitempty" json:"set,omitempty"`
+	Lookup        map[string]cfg.String `yaml:"lookup,omitempty" json:"lookup,omitempty"`
+	CacheTTL      duration.Duration     `yaml:"cache_ttl,omitempty" json:"cache_ttl,omitempty"`
+	OnMissing     onMissingBehavior     `yaml:"on_missing,omitempty" json:"on_missing,omitempty"`
+	Secure        bool                  `yaml:"secure,omitempty" json:"secure,omitempty"`
+	Overwrite     *bool                 `yaml:"overwrite,omitempty" json:"overwrite,omitempty"`
+	client        ssmAPI
+	cache         map[string]cacheEntry
+	cacheMu       sync.RWMutex
 }
 
 func New() (task.Task, error) {
@@ -44,6 +77,27 @@ func (p *parameterStore) GetTaskConcurrency() int {
 }
 
 func (p *parameterStore) Init() error {
+
+	if len(p.SetParameters) > 0 && len(p.Lookup) > 0 {
+		return errBothModes
+	}
+
+	if p.OnMissing == `` {
+		p.OnMissing = onMissingError
+	}
+
+	if p.OnMissing != onMissingError && p.OnMissing != onMissingSkip {
+		return fmt.Errorf("invalid on_missing value %q: must be %q or %q", p.OnMissing, onMissingError, onMissingSkip)
+	}
+
+	if p.CacheTTL == 0 && len(p.Lookup) > 0 {
+		p.CacheTTL = duration.Duration(defaultCacheTTL)
+	}
+
+	if len(p.Lookup) > 0 {
+		p.cache = make(map[string]cacheEntry)
+	}
+
 	awsConfig, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return err
@@ -53,7 +107,25 @@ func (p *parameterStore) Init() error {
 	return nil
 }
 
-func (p *parameterStore) Run(input <-chan *record.Record, output chan<- *record.Record) (err error) {
+func (p *parameterStore) Run(input <-chan *record.Record, output chan<- *record.Record) error {
+
+	if input == nil {
+		return errInputRequired
+	}
+
+	if len(p.Lookup) > 0 {
+		return p.lookupParameters(input, output)
+	}
+
+	return p.setParameters(input, output)
+
+}
+
+func (p *parameterStore) setParameters(input <-chan *record.Record, output chan<- *record.Record) error {
+
+	if len(p.SetParameters) == 0 {
+		return errSetRequired
+	}
 
 	for {
 		r, ok := p.GetRecord(input)
@@ -61,7 +133,6 @@ func (p *parameterStore) Run(input <-chan *record.Record, output chan<- *record.
 			break
 		}
 
-		// first let's set parameters
 		for parameterName, parameterQuery := range p.SetParameters {
 			parameterValue, err := parameterQuery.Execute(r.Data)
 			if err != nil {
@@ -86,13 +157,124 @@ func (p *parameterStore) Run(input <-chan *record.Record, output chan<- *record.
 			if _, err := p.client.PutParameter(ctx, putParameterInput); err != nil {
 				return err
 			}
-
-			if output != nil {
-				p.SendRecord(r, output)
-			}
 		}
+
+		p.SendRecord(r, output)
 	}
 
 	return nil
 
+}
+
+func (p *parameterStore) lookupParameters(input <-chan *record.Record, output chan<- *record.Record) error {
+
+	if len(p.Lookup) == 0 {
+		return errLookupRequired
+	}
+
+	for {
+		r, ok := p.GetRecord(input)
+		if !ok {
+			break
+		}
+
+		skipRecord := false
+	lookupKeys:
+		for contextKey, parameterPath := range p.Lookup {
+			value, err := p.lookupValue(parameterPath, r)
+			if err != nil {
+				if errors.Is(err, errParameterNotFound) && p.OnMissing == onMissingSkip {
+					fmt.Printf("WARN: skipping record: %s\n", err)
+					skipRecord = true
+					break lookupKeys
+				}
+				return err
+			}
+
+			r.SetContextValue(contextKey, value)
+		}
+
+		if skipRecord {
+			continue
+		}
+
+		p.SendRecord(r, output)
+	}
+
+	return nil
+
+}
+
+var errParameterNotFound = fmt.Errorf("parameter not found")
+
+func (p *parameterStore) lookupValue(path cfg.String, r *record.Record) (string, error) {
+
+	resolvedPath, err := path.Get(r)
+	if err != nil {
+		return ``, err
+	}
+
+	if cfg.HasUnresolvedContextPlaceholders(resolvedPath) {
+		return ``, cfg.ErrUnresolvedContextPlaceholder("lookup path")
+	}
+
+	if cached, ok := p.getCached(resolvedPath); ok {
+		return cached, nil
+	}
+
+	parameter, err := p.client.GetParameter(ctx, &ssm.GetParameterInput{
+		Name:           aws.String(resolvedPath),
+		WithDecryption: awsTrue,
+	})
+	if err != nil {
+		var notFound *types.ParameterNotFound
+		if errors.As(err, &notFound) {
+			return ``, fmt.Errorf("%w: %s", errParameterNotFound, resolvedPath)
+		}
+		return ``, err
+	}
+
+	if parameter == nil || parameter.Parameter == nil || parameter.Parameter.Value == nil {
+		return ``, fmt.Errorf("%w: %s", errParameterNotFound, resolvedPath)
+	}
+
+	value := *parameter.Parameter.Value
+	p.setCached(resolvedPath, value)
+
+	return value, nil
+
+}
+
+func (p *parameterStore) getCached(path string) (string, bool) {
+	if time.Duration(p.CacheTTL) == 0 {
+		return ``, false
+	}
+
+	p.cacheMu.RLock()
+	defer p.cacheMu.RUnlock()
+
+	entry, ok := p.cache[path]
+	if !ok {
+		return ``, false
+	}
+
+	if time.Since(entry.fetchedAt) > time.Duration(p.CacheTTL) {
+		return ``, false
+	}
+
+	return entry.value, true
+}
+
+func (p *parameterStore) setCached(path, value string) {
+	if time.Duration(p.CacheTTL) == 0 {
+		return
+	}
+
+	p.cacheMu.Lock()
+	defer p.cacheMu.Unlock()
+
+	p.cache[path] = cacheEntry{
+		value:     value,
+		fetchedAt: time.Now(),
+	}
 }

--- a/internal/pkg/pipeline/task/aws/parameter_store/parameter_store.go
+++ b/internal/pkg/pipeline/task/aws/parameter_store/parameter_store.go
@@ -214,10 +214,6 @@ func (p *parameterStore) lookupValue(path cfg.String, r *record.Record) (string,
 		return ``, err
 	}
 
-	if cfg.HasUnresolvedContextPlaceholders(resolvedPath) {
-		return ``, cfg.ErrUnresolvedContextPlaceholder("lookup path")
-	}
-
 	if cached, ok := p.getCached(resolvedPath); ok {
 		return cached, nil
 	}

--- a/internal/pkg/pipeline/task/aws/parameter_store/parameter_store.go
+++ b/internal/pkg/pipeline/task/aws/parameter_store/parameter_store.go
@@ -193,7 +193,12 @@ func (p *parameterStore) putParameter(name, value string) error {
 func (p *parameterStore) lookupParameters(r *record.Record) error {
 
 	for contextKey, parameterPath := range p.Lookup {
-		value, err := p.getParameter(parameterPath, r)
+		parameterName, err := parameterPath.Get(r)
+		if err != nil {
+			return err
+		}
+
+		value, err := p.getParameter(parameterName)
 		if err != nil {
 			return err
 		}
@@ -205,35 +210,30 @@ func (p *parameterStore) lookupParameters(r *record.Record) error {
 
 }
 
-func (p *parameterStore) getParameter(path cfg.String, r *record.Record) (string, error) {
+func (p *parameterStore) getParameter(name string) (string, error) {
 
-	resolvedPath, err := path.Get(r)
-	if err != nil {
-		return ``, err
-	}
-
-	if cached, ok := p.getCached(resolvedPath); ok {
+	if cached, ok := p.getCached(name); ok {
 		return cached, nil
 	}
 
 	parameter, err := p.client.GetParameter(ctx, &ssm.GetParameterInput{
-		Name:           aws.String(resolvedPath),
+		Name:           aws.String(name),
 		WithDecryption: awsTrue,
 	})
 	if err != nil {
 		var notFound *types.ParameterNotFound
 		if errors.As(err, &notFound) {
-			return ``, fmt.Errorf("%w: %s", errParameterNotFound, resolvedPath)
+			return ``, fmt.Errorf("%w: %s", errParameterNotFound, name)
 		}
 		return ``, err
 	}
 
 	if parameter == nil || parameter.Parameter == nil || parameter.Parameter.Value == nil {
-		return ``, fmt.Errorf("%w: %s", errParameterNotFound, resolvedPath)
+		return ``, fmt.Errorf("%w: %s", errParameterNotFound, name)
 	}
 
 	value := *parameter.Parameter.Value
-	p.setCached(resolvedPath, value)
+	p.setCached(name, value)
 
 	return value, nil
 

--- a/internal/pkg/pipeline/task/aws/parameter_store/parameter_store.go
+++ b/internal/pkg/pipeline/task/aws/parameter_store/parameter_store.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 
-	cfg "github.com/patterninc/caterpillar/internal/pkg/config"
+	"github.com/patterninc/caterpillar/internal/pkg/config"
 	"github.com/patterninc/caterpillar/internal/pkg/duration"
 	"github.com/patterninc/caterpillar/internal/pkg/jq"
 	"github.com/patterninc/caterpillar/internal/pkg/pipeline/record"
@@ -51,12 +51,12 @@ type cacheEntry struct {
 
 type parameterStore struct {
 	task.Base     `yaml:",inline" json:",inline"`
-	SetParameters map[string]*jq.Query  `yaml:"set,omitempty" json:"set,omitempty"`
-	Lookup        map[string]cfg.String `yaml:"lookup,omitempty" json:"lookup,omitempty"`
-	CacheTTL      duration.Duration     `yaml:"cache_ttl,omitempty" json:"cache_ttl,omitempty"`
-	OnMissing     onMissingBehavior     `yaml:"on_missing,omitempty" json:"on_missing,omitempty"`
-	Secure        bool                  `yaml:"secure,omitempty" json:"secure,omitempty"`
-	Overwrite     *bool                 `yaml:"overwrite,omitempty" json:"overwrite,omitempty"`
+	SetParameters map[string]*jq.Query     `yaml:"set,omitempty" json:"set,omitempty"`
+	Lookup        map[string]config.String `yaml:"lookup,omitempty" json:"lookup,omitempty"`
+	CacheTTL      duration.Duration        `yaml:"cache_ttl,omitempty" json:"cache_ttl,omitempty"`
+	OnMissing     onMissingBehavior        `yaml:"on_missing,omitempty" json:"on_missing,omitempty"`
+	Secure        bool                     `yaml:"secure,omitempty" json:"secure,omitempty"`
+	Overwrite     *bool                    `yaml:"overwrite,omitempty" json:"overwrite,omitempty"`
 	client        ssmAPI
 	cache         map[string]cacheEntry
 	cacheMu       sync.RWMutex
@@ -103,12 +103,12 @@ func (p *parameterStore) Init() error {
 		p.cache = make(map[string]cacheEntry)
 	}
 
-	awsConfig, err := config.LoadDefaultConfig(ctx)
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
 	if err != nil {
 		return err
 	}
 
-	p.client = ssm.NewFromConfig(awsConfig)
+	p.client = ssm.NewFromConfig(cfg)
 	return nil
 }
 
@@ -152,18 +152,18 @@ func (p *parameterStore) Run(input <-chan *record.Record, output chan<- *record.
 
 func (p *parameterStore) setParameters(r *record.Record) error {
 
-	for parameterName, parameterQuery := range p.SetParameters {
-		parameterValue, err := parameterQuery.Execute(r.Data)
+	for name, query := range p.SetParameters {
+		result, err := query.Execute(r.Data)
 		if err != nil {
 			return err
 		}
 
-		parameterValueString, isString := parameterValue.(string)
-		if !isString {
-			return fmt.Errorf("%s parameter value is not string", parameterName)
+		value, ok := result.(string)
+		if !ok {
+			return fmt.Errorf("%s parameter value is not string", name)
 		}
 
-		if err := p.putParameter(parameterName, parameterValueString); err != nil {
+		if err := p.putParameter(name, value); err != nil {
 			return err
 		}
 	}
@@ -174,17 +174,17 @@ func (p *parameterStore) setParameters(r *record.Record) error {
 
 func (p *parameterStore) putParameter(name, value string) error {
 
-	putParameterInput := &ssm.PutParameterInput{
+	input := &ssm.PutParameterInput{
 		Name:      aws.String(name),
 		Value:     aws.String(value),
 		Overwrite: p.Overwrite,
 	}
 
 	if p.Secure {
-		putParameterInput.Type = types.ParameterTypeSecureString
+		input.Type = types.ParameterTypeSecureString
 	}
 
-	_, err := p.client.PutParameter(ctx, putParameterInput)
+	_, err := p.client.PutParameter(ctx, input)
 
 	return err
 
@@ -192,18 +192,18 @@ func (p *parameterStore) putParameter(name, value string) error {
 
 func (p *parameterStore) lookupParameters(r *record.Record) error {
 
-	for contextKey, parameterPath := range p.Lookup {
-		parameterName, err := parameterPath.Get(r)
+	for key, path := range p.Lookup {
+		name, err := path.Get(r)
 		if err != nil {
 			return err
 		}
 
-		value, err := p.getParameter(parameterName)
+		value, err := p.getParameter(name)
 		if err != nil {
 			return err
 		}
 
-		r.SetContextValue(contextKey, value)
+		r.SetContextValue(key, value)
 	}
 
 	return nil
@@ -216,7 +216,7 @@ func (p *parameterStore) getParameter(name string) (string, error) {
 		return cached, nil
 	}
 
-	parameter, err := p.client.GetParameter(ctx, &ssm.GetParameterInput{
+	out, err := p.client.GetParameter(ctx, &ssm.GetParameterInput{
 		Name:           aws.String(name),
 		WithDecryption: awsTrue,
 	})
@@ -228,18 +228,18 @@ func (p *parameterStore) getParameter(name string) (string, error) {
 		return ``, err
 	}
 
-	if parameter == nil || parameter.Parameter == nil || parameter.Parameter.Value == nil {
+	if out == nil || out.Parameter == nil || out.Parameter.Value == nil {
 		return ``, fmt.Errorf("%w: %s", errParameterNotFound, name)
 	}
 
-	value := *parameter.Parameter.Value
+	value := *out.Parameter.Value
 	p.setCached(name, value)
 
 	return value, nil
 
 }
 
-func (p *parameterStore) getCached(path string) (string, bool) {
+func (p *parameterStore) getCached(name string) (string, bool) {
 	if time.Duration(p.CacheTTL) == 0 {
 		return ``, false
 	}
@@ -247,7 +247,7 @@ func (p *parameterStore) getCached(path string) (string, bool) {
 	p.cacheMu.RLock()
 	defer p.cacheMu.RUnlock()
 
-	entry, ok := p.cache[path]
+	entry, ok := p.cache[name]
 	if !ok {
 		return ``, false
 	}
@@ -259,7 +259,7 @@ func (p *parameterStore) getCached(path string) (string, bool) {
 	return entry.value, true
 }
 
-func (p *parameterStore) setCached(path, value string) {
+func (p *parameterStore) setCached(name, value string) {
 	if time.Duration(p.CacheTTL) == 0 {
 		return
 	}
@@ -267,7 +267,7 @@ func (p *parameterStore) setCached(path, value string) {
 	p.cacheMu.Lock()
 	defer p.cacheMu.Unlock()
 
-	p.cache[path] = cacheEntry{
+	p.cache[name] = cacheEntry{
 		value:     value,
 		fetchedAt: time.Now(),
 	}

--- a/internal/pkg/pipeline/task/aws/parameter_store/parameter_store.go
+++ b/internal/pkg/pipeline/task/aws/parameter_store/parameter_store.go
@@ -126,7 +126,14 @@ func (p *parameterStore) Run(input <-chan *record.Record, output chan<- *record.
 			break
 		}
 
-		if err := p.processRecord(r); err != nil {
+		var err error
+		if len(p.Lookup) > 0 {
+			err = p.lookupParameters(r)
+		} else {
+			err = p.setParameters(r)
+		}
+
+		if err != nil {
 			// a missing parameter is the one failure the pipeline author can route,
 			// so a single misconfigured tenant need not stop every other one
 			if errors.Is(err, errParameterNotFound) && p.OnMissing == onMissingSkip {
@@ -143,16 +150,6 @@ func (p *parameterStore) Run(input <-chan *record.Record, output chan<- *record.
 
 }
 
-func (p *parameterStore) processRecord(r *record.Record) error {
-
-	if len(p.Lookup) > 0 {
-		return p.lookupParameters(r)
-	}
-
-	return p.setParameters(r)
-
-}
-
 func (p *parameterStore) setParameters(r *record.Record) error {
 
 	for parameterName, parameterQuery := range p.SetParameters {
@@ -166,7 +163,7 @@ func (p *parameterStore) setParameters(r *record.Record) error {
 			return fmt.Errorf("%s parameter value is not string", parameterName)
 		}
 
-		if err := p.setParameter(parameterName, parameterValueString); err != nil {
+		if err := p.putParameter(parameterName, parameterValueString); err != nil {
 			return err
 		}
 	}
@@ -175,7 +172,7 @@ func (p *parameterStore) setParameters(r *record.Record) error {
 
 }
 
-func (p *parameterStore) setParameter(name, value string) error {
+func (p *parameterStore) putParameter(name, value string) error {
 
 	putParameterInput := &ssm.PutParameterInput{
 		Name:      aws.String(name),
@@ -196,7 +193,7 @@ func (p *parameterStore) setParameter(name, value string) error {
 func (p *parameterStore) lookupParameters(r *record.Record) error {
 
 	for contextKey, parameterPath := range p.Lookup {
-		value, err := p.lookupValue(parameterPath, r)
+		value, err := p.getParameter(parameterPath, r)
 		if err != nil {
 			return err
 		}
@@ -208,7 +205,7 @@ func (p *parameterStore) lookupParameters(r *record.Record) error {
 
 }
 
-func (p *parameterStore) lookupValue(path cfg.String, r *record.Record) (string, error) {
+func (p *parameterStore) getParameter(path cfg.String, r *record.Record) (string, error) {
 
 	resolvedPath, err := path.Get(r)
 	if err != nil {

--- a/internal/pkg/pipeline/task/aws/parameter_store/parameter_store.go
+++ b/internal/pkg/pipeline/task/aws/parameter_store/parameter_store.go
@@ -32,10 +32,11 @@ var (
 	ctx     = context.Background()
 	awsTrue = aws.Bool(true)
 
-	errBothModes      = fmt.Errorf(`set and lookup are mutually exclusive`)
-	errLookupRequired = fmt.Errorf(`lookup must be set when task has an input channel`)
-	errSetRequired    = fmt.Errorf(`set must be set when task has an input channel`)
-	errInputRequired  = fmt.Errorf(`aws_parameter_store requires an input channel`)
+	errBothModes     = fmt.Errorf(`set and lookup are mutually exclusive`)
+	errNoMode        = fmt.Errorf(`either set or lookup must be configured`)
+	errInputRequired = fmt.Errorf(`aws_parameter_store requires an input channel`)
+
+	errParameterNotFound = fmt.Errorf(`parameter not found`)
 )
 
 type ssmAPI interface {
@@ -82,6 +83,10 @@ func (p *parameterStore) Init() error {
 		return errBothModes
 	}
 
+	if len(p.SetParameters) == 0 && len(p.Lookup) == 0 {
+		return errNoMode
+	}
+
 	if p.OnMissing == `` {
 		p.OnMissing = onMissingError
 	}
@@ -109,103 +114,99 @@ func (p *parameterStore) Init() error {
 
 func (p *parameterStore) Run(input <-chan *record.Record, output chan<- *record.Record) error {
 
+	// GetRecord treats a nil channel as an immediately closed one, so without this
+	// a source-positioned task would exit successfully having done nothing
 	if input == nil {
 		return errInputRequired
 	}
 
+	for {
+		r, ok := p.GetRecord(input)
+		if !ok {
+			break
+		}
+
+		if err := p.processRecord(r); err != nil {
+			// a missing parameter is the one failure the pipeline author can route,
+			// so a single misconfigured tenant need not stop every other one
+			if errors.Is(err, errParameterNotFound) && p.OnMissing == onMissingSkip {
+				fmt.Printf("WARN: skipping record: %s\n", err)
+				continue
+			}
+			return err
+		}
+
+		p.SendRecord(r, output)
+	}
+
+	return nil
+
+}
+
+func (p *parameterStore) processRecord(r *record.Record) error {
+
 	if len(p.Lookup) > 0 {
-		return p.lookupParameters(input, output)
+		return p.lookupParameters(r)
 	}
 
-	return p.setParameters(input, output)
+	return p.setParameters(r)
 
 }
 
-func (p *parameterStore) setParameters(input <-chan *record.Record, output chan<- *record.Record) error {
+func (p *parameterStore) setParameters(r *record.Record) error {
 
-	if len(p.SetParameters) == 0 {
-		return errSetRequired
-	}
-
-	for {
-		r, ok := p.GetRecord(input)
-		if !ok {
-			break
+	for parameterName, parameterQuery := range p.SetParameters {
+		parameterValue, err := parameterQuery.Execute(r.Data)
+		if err != nil {
+			return err
 		}
 
-		for parameterName, parameterQuery := range p.SetParameters {
-			parameterValue, err := parameterQuery.Execute(r.Data)
-			if err != nil {
-				return err
-			}
-
-			parameterValueString, isString := parameterValue.(string)
-			if !isString {
-				return fmt.Errorf("%s parameter value is not string", parameterName)
-			}
-
-			putParameterInput := &ssm.PutParameterInput{
-				Name:      aws.String(parameterName),
-				Value:     aws.String(parameterValueString),
-				Overwrite: p.Overwrite,
-			}
-
-			if p.Secure {
-				putParameterInput.Type = types.ParameterTypeSecureString
-			}
-
-			if _, err := p.client.PutParameter(ctx, putParameterInput); err != nil {
-				return err
-			}
+		parameterValueString, isString := parameterValue.(string)
+		if !isString {
+			return fmt.Errorf("%s parameter value is not string", parameterName)
 		}
 
-		p.SendRecord(r, output)
+		if err := p.setParameter(parameterName, parameterValueString); err != nil {
+			return err
+		}
 	}
 
 	return nil
 
 }
 
-func (p *parameterStore) lookupParameters(input <-chan *record.Record, output chan<- *record.Record) error {
+func (p *parameterStore) setParameter(name, value string) error {
 
-	if len(p.Lookup) == 0 {
-		return errLookupRequired
+	putParameterInput := &ssm.PutParameterInput{
+		Name:      aws.String(name),
+		Value:     aws.String(value),
+		Overwrite: p.Overwrite,
 	}
 
-	for {
-		r, ok := p.GetRecord(input)
-		if !ok {
-			break
+	if p.Secure {
+		putParameterInput.Type = types.ParameterTypeSecureString
+	}
+
+	_, err := p.client.PutParameter(ctx, putParameterInput)
+
+	return err
+
+}
+
+func (p *parameterStore) lookupParameters(r *record.Record) error {
+
+	for contextKey, parameterPath := range p.Lookup {
+		value, err := p.lookupValue(parameterPath, r)
+		if err != nil {
+			return err
 		}
 
-		skipRecord := false
-	lookupKeys:
-		for contextKey, parameterPath := range p.Lookup {
-			value, err := p.lookupValue(parameterPath, r)
-			if err != nil {
-				if errors.Is(err, errParameterNotFound) && p.OnMissing == onMissingSkip {
-					fmt.Printf("WARN: skipping record: %s\n", err)
-					skipRecord = true
-					break lookupKeys
-				}
-				return err
-			}
-
-			r.SetContextValue(contextKey, value)
-		}
-
-		if skipRecord {
-			continue
-		}
-
-		p.SendRecord(r, output)
+		r.SetContextValue(contextKey, value)
 	}
 
 	return nil
 
 }
-
-var errParameterNotFound = fmt.Errorf("parameter not found")
 
 func (p *parameterStore) lookupValue(path cfg.String, r *record.Record) (string, error) {
 

--- a/internal/pkg/pipeline/task/http/http.go
+++ b/internal/pkg/pipeline/task/http/http.go
@@ -34,23 +34,6 @@ var (
 	ctx = context.Background()
 )
 
-type oauth struct {
-	ConsumerKey     string   `yaml:"consumer_key" json:"consumer_key"`
-	ConsumerSecret  string   `yaml:"consumer_secret" json:"consumer_secret"`
-	Token           string   `yaml:"token" json:"token"`
-	TokenSecret     string   `yaml:"token_secret" json:"token_secret"`
-	Version         string   `yaml:"version,omitempty" json:"version,omitempty"`
-	SignatureMethod string   `yaml:"signature_method,omitempty" json:"signature_method,omitempty"`
-	Realm           string   `yaml:"realm,omitempty" json:"realm,omitempty"`
-	PrivateKey      string   `yaml:"private_key,omitempty" json:"private_key,omitempty"`
-	Subject         string   `yaml:"subject,omitempty" json:"subject,omitempty"`
-	Issuer          string   `yaml:"issuer,omitempty" json:"issuer,omitempty"`
-	Audience        string   `yaml:"audience,omitempty" json:"audience,omitempty"`
-	TokenURI        string   `yaml:"token_uri,omitempty" json:"token_uri,omitempty"`
-	GrantType       string   `yaml:"grant_type,omitempty" json:"grant_type,omitempty"`
-	Scope           []string `yaml:"scope,omitempty" json:"scope,omitempty"`
-}
-
 type httpCore struct {
 	task.Base        `yaml:",inline" json:",inline"`
 	Method           string            `yaml:"method,omitempty" json:"method,omitempty"`
@@ -118,7 +101,7 @@ func (h *httpCore) newFromInput(data []byte) (*httpCore, error) {
 		ExpectedStatuses: h.ExpectedStatuses,
 		Body:             h.Body,
 		NextPage:         h.NextPage,
-		Oauth:            h.Oauth,
+		Oauth:            h.Oauth.copy(),
 		Proxy:            h.Proxy,
 		Timeout:          h.Timeout,
 		MaxRetries:       h.MaxRetries,
@@ -126,7 +109,7 @@ func (h *httpCore) newFromInput(data []byte) (*httpCore, error) {
 	}
 
 	if err := json.Unmarshal(data, newHttp); err != nil {
-		return nil, fmt.Errorf("cannot parse http payload [%s]: %s", err, string(data))
+		return nil, fmt.Errorf("cannot parse http payload: %w", err)
 	}
 
 	// we only append headers that are present in the current task (h) and missing in the new one
@@ -191,7 +174,7 @@ func (h *httpCore) processItem(rc *record.Record, output chan<- *record.Record) 
 
 	// we have infinite loop to account for potential pagination
 	for {
-		result, err := h.call(endpoint)
+		result, err := h.call(endpoint, rc)
 
 		if err != nil {
 			return err
@@ -288,7 +271,7 @@ func (h *httpCore) processItem(rc *record.Record, output chan<- *record.Record) 
 
 }
 
-func (h *httpCore) call(endpoint string) (*result, error) {
+func (h *httpCore) call(endpoint string, rc *record.Record) (*result, error) {
 
 	var lastErr error
 	for attempt := 1; attempt <= h.MaxRetries; attempt++ {
@@ -310,14 +293,7 @@ func (h *httpCore) call(endpoint string) (*result, error) {
 
 		// TODO: support multiple "behaviors" for oauth support
 		if h.Oauth != nil {
-			// apply default values if version and hash method are missing
-			if h.Oauth.Version == `` {
-				h.Oauth.Version = defaultOAuthVersion
-			}
-			if h.Oauth.SignatureMethod == `` {
-				h.Oauth.SignatureMethod = defaultSignatureMethod
-			}
-			if err := h.oauth(endpoint, request); err != nil {
+			if err := h.oauth(endpoint, request, rc); err != nil {
 				lastErr = err
 				if attempt < h.MaxRetries {
 					continue

--- a/internal/pkg/pipeline/task/http/oauth.go
+++ b/internal/pkg/pipeline/task/http/oauth.go
@@ -3,24 +3,30 @@ package http
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/patterninc/caterpillar/internal/pkg/pipeline/record"
 )
 
 const (
 	headerAuthorization = `Authorization`
 )
 
-func (h *httpCore) oauth(endpoint string, r *http.Request) error {
+func (h *httpCore) oauth(endpoint string, r *http.Request, rc *record.Record) error {
 
-	// let's choose the behavior
-	behavior, found := map[string]func(string, *http.Request) error{
-		`1.0`: h.oauth1,
-		`2.0`: h.oauth2,
-	}[h.Oauth.Version]
-
-	if !found {
-		return fmt.Errorf("unsupported oauth behavior: %v", h.Oauth.Version)
+	resolved, err := h.Oauth.resolve(rc)
+	if err != nil {
+		return err
 	}
 
-	return behavior(endpoint, r)
+	behavior, found := map[string]func(string, *http.Request, *resolvedOAuth) error{
+		`1.0`: h.oauth1,
+		`2.0`: h.oauth2,
+	}[resolved.Version]
+
+	if !found {
+		return fmt.Errorf("unsupported oauth behavior: %v", resolved.Version)
+	}
+
+	return behavior(endpoint, r, resolved)
 
 }

--- a/internal/pkg/pipeline/task/http/oauth1.go
+++ b/internal/pkg/pipeline/task/http/oauth1.go
@@ -63,7 +63,7 @@ func shouldEscape(c byte) bool {
 	return true
 }
 
-func (h *httpCore) oauth1(endpoint string, r *http.Request) (err error) {
+func (h *httpCore) oauth1(endpoint string, r *http.Request, oauth *resolvedOAuth) (err error) {
 
 	// let's parse the endpoint we got to...
 	parsedURL, err := url.Parse(endpoint)
@@ -81,11 +81,11 @@ func (h *httpCore) oauth1(endpoint string, r *http.Request) (err error) {
 
 	// set oauth parameters
 	oauthParameters := map[string]string{
-		`oauth_consumer_key`:     h.Oauth.ConsumerKey,
-		`oauth_signature_method`: h.Oauth.SignatureMethod,
+		`oauth_consumer_key`:     oauth.ConsumerKey,
+		`oauth_signature_method`: oauth.SignatureMethod,
 		`oauth_timestamp`:        fmt.Sprintf("%d", time.Now().Unix()),
-		`oauth_token`:            h.Oauth.Token,
-		`oauth_version`:          h.Oauth.Version,
+		`oauth_token`:            oauth.Token,
+		`oauth_version`:          oauth.Version,
 	}
 
 	if oauthParameters[`oauth_nonce`], err = getNonce(); err != nil {
@@ -108,12 +108,12 @@ func (h *httpCore) oauth1(endpoint string, r *http.Request) (err error) {
 	sort.Strings(parameters)
 
 	baseString := strings.Join([]string{h.Method, percentEncode(parsedURL.String()), percentEncode(strings.Join(parameters, `&`))}, "&")
-	signature := url.QueryEscape(sha256Hash(baseString, h.Oauth.ConsumerSecret+`&`+h.Oauth.TokenSecret))
+	signature := url.QueryEscape(sha256Hash(baseString, oauth.ConsumerSecret+`&`+oauth.TokenSecret))
 
 	// generate authorization header value
 	authorizationParts = append(authorizationParts, fmt.Sprintf("%s=%q", `oauth_signature`, signature))
-	if h.Oauth.Realm != `` {
-		authorizationParts = append(authorizationParts, fmt.Sprintf("%s=%q", `realm`, h.Oauth.Realm))
+	if oauth.Realm != `` {
+		authorizationParts = append(authorizationParts, fmt.Sprintf("%s=%q", `realm`, oauth.Realm))
 	}
 	r.Header.Set(headerAuthorization, fmt.Sprintf("OAuth %s", strings.Join(authorizationParts, `,`)))
 

--- a/internal/pkg/pipeline/task/http/oauth2.go
+++ b/internal/pkg/pipeline/task/http/oauth2.go
@@ -22,14 +22,14 @@ const (
 	contentTypeForm = `application/x-www-form-urlencoded`
 )
 
-func (h *httpCore) oauth2(endpoint string, r *http.Request) error {
+func (h *httpCore) oauth2(endpoint string, r *http.Request, oauth *resolvedOAuth) error {
 
-	jwt, err := h.getJWT()
+	jwt, err := getJWT(oauth)
 	if err != nil {
 		return err
 	}
 
-	accessToken, err := h.getOauthToken(jwt)
+	accessToken, err := getOauthToken(oauth, jwt)
 	if err != nil {
 		return err
 	}
@@ -40,23 +40,22 @@ func (h *httpCore) oauth2(endpoint string, r *http.Request) error {
 
 }
 
-func (h *httpCore) getJWT() (string, error) {
+func getJWT(oauth *resolvedOAuth) (string, error) {
 
 	now := time.Now().Unix()
 
 	claims := jwt.MapClaims{
-		"iss":   h.Oauth.Issuer,
-		"sub":   h.Oauth.Subject,
-		"aud":   h.Oauth.Audience,
+		"iss":   oauth.Issuer,
+		"sub":   oauth.Subject,
+		"aud":   oauth.Audience,
 		"iat":   now,
 		"exp":   now + jwtExpiration,
-		"scope": strings.Join(h.Oauth.Scope, " "),
+		"scope": strings.Join(oauth.Scope, " "),
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 
-	// parse private key
-	key, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(h.Oauth.PrivateKey))
+	key, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(oauth.PrivateKey))
 	if err != nil {
 		return ``, err
 	}
@@ -65,14 +64,14 @@ func (h *httpCore) getJWT() (string, error) {
 
 }
 
-func (h *httpCore) getOauthToken(jwt string) (string, error) {
+func getOauthToken(oauth *resolvedOAuth, jwt string) (string, error) {
 
 	data := url.Values{}
 	data.Set(assertionKey, jwt)
-	data.Set(grantTypeKey, h.Oauth.GrantType)
+	data.Set(grantTypeKey, oauth.GrantType)
 	payload := strings.NewReader(data.Encode())
 
-	req, err := http.NewRequest(http.MethodPost, h.Oauth.TokenURI, payload)
+	req, err := http.NewRequest(http.MethodPost, oauth.TokenURI, payload)
 	if err != nil {
 		return ``, err
 	}
@@ -91,11 +90,20 @@ func (h *httpCore) getOauthToken(jwt string) (string, error) {
 		return ``, err
 	}
 
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return ``, fmt.Errorf("oauth token request failed with status %d", resp.StatusCode)
+	}
+
 	var accessTokenResp map[string]interface{}
 	if err = json.Unmarshal(body, &accessTokenResp); err != nil {
 		return ``, err
 	}
 
-	return accessTokenResp[accessTokenKey].(string), nil
+	accessToken, ok := accessTokenResp[accessTokenKey].(string)
+	if !ok || accessToken == `` {
+		return ``, fmt.Errorf("oauth token response missing access_token")
+	}
+
+	return accessToken, nil
 
 }

--- a/internal/pkg/pipeline/task/http/oauth_resolve.go
+++ b/internal/pkg/pipeline/task/http/oauth_resolve.go
@@ -52,25 +52,12 @@ func (o *oauth) copy() *oauth {
 	return &cp
 }
 
-func resolveString(field string, value config.String, r *record.Record) (string, error) {
-	resolved, err := value.Get(r)
-	if err != nil {
-		return ``, err
-	}
-
-	if config.HasUnresolvedContextPlaceholders(resolved) {
-		return ``, config.ErrUnresolvedContextPlaceholder(field)
-	}
-
-	return resolved, nil
-}
-
 func (o *oauth) resolve(r *record.Record) (*resolvedOAuth, error) {
 	if o == nil {
 		return nil, nil
 	}
 
-	version, err := resolveString("oauth.version", o.Version, r)
+	version, err := o.Version.Get(r)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +65,7 @@ func (o *oauth) resolve(r *record.Record) (*resolvedOAuth, error) {
 		version = defaultOAuthVersion
 	}
 
-	signatureMethod, err := resolveString("oauth.signature_method", o.SignatureMethod, r)
+	signatureMethod, err := o.SignatureMethod.Get(r)
 	if err != nil {
 		return nil, err
 	}
@@ -86,64 +73,64 @@ func (o *oauth) resolve(r *record.Record) (*resolvedOAuth, error) {
 		signatureMethod = defaultSignatureMethod
 	}
 
-	consumerKey, err := resolveString("oauth.consumer_key", o.ConsumerKey, r)
+	consumerKey, err := o.ConsumerKey.Get(r)
 	if err != nil {
 		return nil, err
 	}
 
-	consumerSecret, err := resolveString("oauth.consumer_secret", o.ConsumerSecret, r)
+	consumerSecret, err := o.ConsumerSecret.Get(r)
 	if err != nil {
 		return nil, err
 	}
 
-	token, err := resolveString("oauth.token", o.Token, r)
+	token, err := o.Token.Get(r)
 	if err != nil {
 		return nil, err
 	}
 
-	tokenSecret, err := resolveString("oauth.token_secret", o.TokenSecret, r)
+	tokenSecret, err := o.TokenSecret.Get(r)
 	if err != nil {
 		return nil, err
 	}
 
-	realm, err := resolveString("oauth.realm", o.Realm, r)
+	realm, err := o.Realm.Get(r)
 	if err != nil {
 		return nil, err
 	}
 
-	privateKey, err := resolveString("oauth.private_key", o.PrivateKey, r)
+	privateKey, err := o.PrivateKey.Get(r)
 	if err != nil {
 		return nil, err
 	}
 
-	subject, err := resolveString("oauth.subject", o.Subject, r)
+	subject, err := o.Subject.Get(r)
 	if err != nil {
 		return nil, err
 	}
 
-	issuer, err := resolveString("oauth.issuer", o.Issuer, r)
+	issuer, err := o.Issuer.Get(r)
 	if err != nil {
 		return nil, err
 	}
 
-	audience, err := resolveString("oauth.audience", o.Audience, r)
+	audience, err := o.Audience.Get(r)
 	if err != nil {
 		return nil, err
 	}
 
-	tokenURI, err := resolveString("oauth.token_uri", o.TokenURI, r)
+	tokenURI, err := o.TokenURI.Get(r)
 	if err != nil {
 		return nil, err
 	}
 
-	grantType, err := resolveString("oauth.grant_type", o.GrantType, r)
+	grantType, err := o.GrantType.Get(r)
 	if err != nil {
 		return nil, err
 	}
 
 	scope := make([]string, 0, len(o.Scope))
 	for _, scopeValue := range o.Scope {
-		resolved, err := resolveString("oauth.scope", scopeValue, r)
+		resolved, err := scopeValue.Get(r)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/pipeline/task/http/oauth_resolve.go
+++ b/internal/pkg/pipeline/task/http/oauth_resolve.go
@@ -1,0 +1,171 @@
+package http
+
+import (
+	"github.com/patterninc/caterpillar/internal/pkg/config"
+	"github.com/patterninc/caterpillar/internal/pkg/pipeline/record"
+)
+
+type oauth struct {
+	ConsumerKey     config.String   `yaml:"consumer_key" json:"consumer_key"`
+	ConsumerSecret  config.String   `yaml:"consumer_secret" json:"consumer_secret"`
+	Token           config.String   `yaml:"token" json:"token"`
+	TokenSecret     config.String   `yaml:"token_secret" json:"token_secret"`
+	Version         config.String   `yaml:"version,omitempty" json:"version,omitempty"`
+	SignatureMethod config.String   `yaml:"signature_method,omitempty" json:"signature_method,omitempty"`
+	Realm           config.String   `yaml:"realm,omitempty" json:"realm,omitempty"`
+	PrivateKey      config.String   `yaml:"private_key,omitempty" json:"private_key,omitempty"`
+	Subject         config.String   `yaml:"subject,omitempty" json:"subject,omitempty"`
+	Issuer          config.String   `yaml:"issuer,omitempty" json:"issuer,omitempty"`
+	Audience        config.String   `yaml:"audience,omitempty" json:"audience,omitempty"`
+	TokenURI        config.String   `yaml:"token_uri,omitempty" json:"token_uri,omitempty"`
+	GrantType       config.String   `yaml:"grant_type,omitempty" json:"grant_type,omitempty"`
+	Scope           []config.String `yaml:"scope,omitempty" json:"scope,omitempty"`
+}
+
+type resolvedOAuth struct {
+	ConsumerKey     string
+	ConsumerSecret  string
+	Token           string
+	TokenSecret     string
+	Version         string
+	SignatureMethod string
+	Realm           string
+	PrivateKey      string
+	Subject         string
+	Issuer          string
+	Audience        string
+	TokenURI        string
+	GrantType       string
+	Scope           []string
+}
+
+func (o *oauth) copy() *oauth {
+	if o == nil {
+		return nil
+	}
+
+	cp := *o
+	if len(o.Scope) > 0 {
+		cp.Scope = append([]config.String(nil), o.Scope...)
+	}
+
+	return &cp
+}
+
+func resolveString(field string, value config.String, r *record.Record) (string, error) {
+	resolved, err := value.Get(r)
+	if err != nil {
+		return ``, err
+	}
+
+	if config.HasUnresolvedContextPlaceholders(resolved) {
+		return ``, config.ErrUnresolvedContextPlaceholder(field)
+	}
+
+	return resolved, nil
+}
+
+func (o *oauth) resolve(r *record.Record) (*resolvedOAuth, error) {
+	if o == nil {
+		return nil, nil
+	}
+
+	version, err := resolveString("oauth.version", o.Version, r)
+	if err != nil {
+		return nil, err
+	}
+	if version == `` {
+		version = defaultOAuthVersion
+	}
+
+	signatureMethod, err := resolveString("oauth.signature_method", o.SignatureMethod, r)
+	if err != nil {
+		return nil, err
+	}
+	if signatureMethod == `` {
+		signatureMethod = defaultSignatureMethod
+	}
+
+	consumerKey, err := resolveString("oauth.consumer_key", o.ConsumerKey, r)
+	if err != nil {
+		return nil, err
+	}
+
+	consumerSecret, err := resolveString("oauth.consumer_secret", o.ConsumerSecret, r)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := resolveString("oauth.token", o.Token, r)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenSecret, err := resolveString("oauth.token_secret", o.TokenSecret, r)
+	if err != nil {
+		return nil, err
+	}
+
+	realm, err := resolveString("oauth.realm", o.Realm, r)
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey, err := resolveString("oauth.private_key", o.PrivateKey, r)
+	if err != nil {
+		return nil, err
+	}
+
+	subject, err := resolveString("oauth.subject", o.Subject, r)
+	if err != nil {
+		return nil, err
+	}
+
+	issuer, err := resolveString("oauth.issuer", o.Issuer, r)
+	if err != nil {
+		return nil, err
+	}
+
+	audience, err := resolveString("oauth.audience", o.Audience, r)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenURI, err := resolveString("oauth.token_uri", o.TokenURI, r)
+	if err != nil {
+		return nil, err
+	}
+
+	grantType, err := resolveString("oauth.grant_type", o.GrantType, r)
+	if err != nil {
+		return nil, err
+	}
+
+	scope := make([]string, 0, len(o.Scope))
+	for _, scopeValue := range o.Scope {
+		resolved, err := resolveString("oauth.scope", scopeValue, r)
+		if err != nil {
+			return nil, err
+		}
+		if resolved != `` {
+			scope = append(scope, resolved)
+		}
+	}
+
+	return &resolvedOAuth{
+		ConsumerKey:     consumerKey,
+		ConsumerSecret:  consumerSecret,
+		Token:           token,
+		TokenSecret:     tokenSecret,
+		Version:         version,
+		SignatureMethod: signatureMethod,
+		Realm:           realm,
+		PrivateKey:      privateKey,
+		Subject:         subject,
+		Issuer:          issuer,
+		Audience:        audience,
+		TokenURI:        tokenURI,
+		GrantType:       grantType,
+		Scope:           scope,
+	}, nil
+}


### PR DESCRIPTION
## Summary

Unblocks running one pipeline process for many tenants, selecting credentials per record from a key derived from the incoming request. Two changes, both in caterpillar only.

**Per-record oauth credentials.** The fourteen `oauth` fields become `config.String` and `scope` becomes `[]config.String`, so they can carry `{{ context "..." }}`. `*record.Record` is threaded through `call` -> `oauth` -> `oauth1`/`oauth2`, and resolution happens once per request into a `resolvedOAuth` value. Two correctness fixes ride along:

- `newFromInput` copied `Oauth` as a pointer and then unmarshalled record JSON over it, so a per-record oauth block rewrote shared task state. It now deep-copies. This was only safe while `task_concurrency` was 1.
- `call` mutated `h.Oauth.Version` and `h.Oauth.SignatureMethod` in place to apply defaults. Defaults are now resolved locally.

**Per-record parameter lookup.** `aws_parameter_store` gains a `lookup:` field whose paths are `config.String`, resolved per record. Values are written to record **context**, never to data, since data flows into sinks and error messages. Successful lookups are cached, keyed on the **resolved** path (keying on the template would collapse all tenants into one entry and serve one account's credentials to another). `cache_ttl` defaults to 5m; `cache_ttl: 0` disables. Missing parameters are never cached and follow a task-level `on_missing`, either `error` (default) or `skip`.

The documented but unimplemented `get:` source-read mode is removed, superseded by `lookup:`.

Also hardens `getOauthToken`, which never checked HTTP status and then did an unchecked type assertion on `access_token`. Any provider error response panicked the process, with no `recover` in the task goroutine. Per-record credentials make expired keys and revoked service accounts routine runtime conditions, so this would have started firing regularly.

`internal/pkg/config` is untouched by this PR.

## Behaviour notes for reviewers

- `on_missing: error` returns from `Run`, which stops the task for every tenant in the process. For an `http_server`-sourced pipeline the process stays alive and no exit status ever surfaces, so recovery needs a restart. `skip` is the better choice for long-running multi-tenant pipelines; `error` remains the default because it suits batch pipelines where the exit code is seen.
- Transient SSM failures are not routed through `on_missing`. A throttle or timeout is a failure to determine the answer rather than an answer, and treating it as absence would silently drop records during an SSM blip.
- Credentials from context only work on tasks with an input, because context lives on records. A task in source position calls `String.Get(nil)`, which returns early with a nil error and leaves the placeholder as a literal value. That pre-existing behaviour is unchanged here and is followed up separately; see below.

## Follow-up, not in this PR

`String.Get(nil)` silently passes an unresolved context placeholder through instead of erroring. In source position that surfaces indirectly: as `private_key` it becomes an invalid-PEM error pointing at the stored key rather than at task placement, and as `issuer` or `audience` the JWT signs cleanly and the provider rejects it. Detecting residual placeholders is worth doing in `config` so every caller benefits, which makes it a change to `file.path`, `sftp.path`, and `jq.path` behaviour too. Deferred to its own PR for that reason.

## Test plan

- [x] `go build ./internal/...` and `gofmt` clean
- [x] Cache keys on the resolved path, misses are not cached, and a miss succeeds once the parameter appears - verified locally
- [x] oauth1 and oauth2 resolve context-supplied values - verified locally
- [x] `go test -race` with `task_concurrency > 1` and distinct per-record credentials - verified locally against the shared-pointer bug
- [ ] Deploy and exercise a multi-tenant pipeline with `on_missing: skip`

Local validation was run without committing test files, so none of the above is guarded in CI.