### PR TITLE
feat(aws_parameter_store): add per-record parameter lookup

### DIFF
--- a/internal/pkg/pipeline/task/aws/parameter_store/README.md
+++ b/internal/pkg/pipeline/task/aws/parameter_store/README.md
@@ -59,7 +59,7 @@ tasks:
     overwrite: true
 ```
 
-### Lookup mode - Fetch per-record values into context:
+### Lookup mode - Fetch per-record credentials into context:
 ```yaml
 tasks:
   - name: extract_slug
@@ -74,10 +74,15 @@ tasks:
       private_key: /caterpillar/kms_google_drive_ingestion/accounts/{{ context "slug" }}/private_key
     cache_ttl: 5m
     on_missing: skip
+  - name: call_api
+    type: http
+    endpoint: https://www.googleapis.com/drive/v3/files
+    oauth:
+      version: "2.0"
+      issuer: "{{ context \"client_email\" }}"
+      subject: "{{ context \"client_email\" }}"
+      private_key: "{{ context \"private_key\" }}"
 ```
-
-Each downstream task reads the values with `{{ context "client_email" }}`, in any
-field whose type is `config.String`.
 
 ## Use Cases
 

--- a/internal/pkg/pipeline/task/aws/parameter_store/README.md
+++ b/internal/pkg/pipeline/task/aws/parameter_store/README.md
@@ -1,21 +1,30 @@
 # AWS Parameter Store Task
 
-The `aws_parameter_store` task reads from or writes to AWS Systems Manager Parameter Store, enabling secure configuration management and parameter operations.
+The `aws_parameter_store` task writes to or reads from AWS Systems Manager Parameter Store.
 
 ## Function
 
-The AWS Parameter Store task operates in two modes depending on whether an input channel is provided:
+The task operates in two modes, selected by which field is configured:
 
-- **Write mode** (with input channel): Receives records from the input channel and sets parameters in Parameter Store based on the data
-- **Read mode** (no input channel): Retrieves parameters from Parameter Store and sends them to the output channel
+- **Write mode**: Receives records from the input channel and sets parameters in Parameter Store based on the data. Requires `set`.
+- **Lookup mode**: Fetches parameters per record and writes the decrypted values into record context. Requires `lookup`.
+
+`set` and `lookup` are mutually exclusive. The task always requires an input channel.
+
+| Mode | Field | Behaviour |
+|------|-------|-----------|
+| Write | `set` | Sets the `set` parameters from each record, then forwards that record downstream unchanged |
+| Lookup | `lookup` | Fetches parameters whose paths may vary per record, writes values to record context, then forwards the record |
 
 ## Input Channel
 
-In write mode, accepts `*record.Record` objects containing data that can be used to set parameters in Parameter Store.
+Accepts `*record.Record` objects. Lookup paths may reference record context via `{{ context "..." }}`.
 
 ## Output Channel
 
-In read mode, sends `*record.Record` objects containing parameter values from Parameter Store.
+In write mode, each input record is forwarded downstream once, regardless of how many parameters `set` writes.
+
+In lookup mode, each input record is forwarded after its context is populated. `SecureString` values are decrypted.
 
 ## Configuration Fields
 
@@ -23,17 +32,24 @@ In read mode, sends `*record.Record` objects containing parameter values from Pa
 |-------|------|---------|-------------|
 | `name` | string | - | Task name for identification |
 | `type` | string | `aws_parameter_store` | Must be "aws_parameter_store" |
-| `set` | map[string]string | - | Parameters to set using JQ expressions |
-| `get` | map[string]string | - | Parameters to retrieve from Parameter Store |
-| `secure` | bool | `true` | Whether to store parameters as SecureString |
+| `set` | map[string]string | - | Parameters to set, keyed by parameter name, valued by JQ expression |
+| `lookup` | map[string]string | - | Parameters to retrieve per record, keyed by context field name, valued by parameter path |
+| `cache_ttl` | duration | `5m` | How long successful lookups are cached. `0` disables caching. |
+| `on_missing` | string | `error` | Behaviour when a parameter does not exist: `error` stops the task; `skip` logs and drops the record |
+| `secure` | bool | `true` | Whether to store parameters as SecureString (write mode only) |
 | `overwrite` | bool | `true` | Whether to overwrite existing parameters |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
+
+Only successful lookups are cached. Missing parameters are never cached and always follow `on_missing`.
 
 ## Example Configurations
 
 ### Write mode - Set parameters from pipeline data:
 ```yaml
 tasks:
+  - name: source
+    type: file
+    path: credentials.json
   - name: set_config
     type: aws_parameter_store
     set:
@@ -43,22 +59,31 @@ tasks:
     overwrite: true
 ```
 
-### Read mode - Get parameters from Parameter Store:
+### Lookup mode - Fetch per-record values into context:
 ```yaml
 tasks:
-  - name: get_config
+  - name: extract_slug
+    type: jq
+    path: .
+    context:
+      slug: .channel_id
+  - name: fetch_credentials
     type: aws_parameter_store
-    get:
-      "api_key": "/prod/api/key"
-      "database_url": "/prod/database/url"
+    lookup:
+      client_email: /caterpillar/kms_google_drive_ingestion/accounts/{{ context "slug" }}/client_email
+      private_key: /caterpillar/kms_google_drive_ingestion/accounts/{{ context "slug" }}/private_key
+    cache_ttl: 5m
+    on_missing: skip
 ```
 
+Each downstream task reads the values with `{{ context "client_email" }}`, in any
+field whose type is `config.String`.
 
 ## Use Cases
 
 - **Configuration management**: Store and retrieve application configuration
 - **Secret management**: Securely store and retrieve sensitive data
 - **Dynamic configuration**: Update parameters based on pipeline data
+- **Multi-tenant credentials**: Resolve per-tenant secrets from SSM at runtime
 - **Environment setup**: Configure different environments with different parameters
 - **Data persistence**: Store pipeline results for later use
-- **Cross-pipeline sharing**: Share data between different pipeline runs

--- a/internal/pkg/pipeline/task/aws/parameter_store/parameter_store.go
+++ b/internal/pkg/pipeline/task/aws/parameter_store/parameter_store.go
@@ -2,30 +2,64 @@ package parameter_store
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 
+	"github.com/patterninc/caterpillar/internal/pkg/config"
+	"github.com/patterninc/caterpillar/internal/pkg/duration"
 	"github.com/patterninc/caterpillar/internal/pkg/jq"
 	"github.com/patterninc/caterpillar/internal/pkg/pipeline/record"
 	"github.com/patterninc/caterpillar/internal/pkg/pipeline/task"
 )
 
+const defaultCacheTTL = 5 * time.Minute
+
+type onMissingBehavior string
+
+const (
+	onMissingError onMissingBehavior = "error"
+	onMissingSkip  onMissingBehavior = "skip"
+)
+
 var (
 	ctx     = context.Background()
 	awsTrue = aws.Bool(true)
+
+	errBothModes     = fmt.Errorf(`set and lookup are mutually exclusive`)
+	errNoMode        = fmt.Errorf(`either set or lookup must be configured`)
+	errInputRequired = fmt.Errorf(`aws_parameter_store requires an input channel`)
+
+	errParameterNotFound = fmt.Errorf(`parameter not found`)
 )
+
+type ssmAPI interface {
+	GetParameter(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
+	PutParameter(ctx context.Context, params *ssm.PutParameterInput, optFns ...func(*ssm.Options)) (*ssm.PutParameterOutput, error)
+}
+
+type cacheEntry struct {
+	value     string
+	fetchedAt time.Time
+}
 
 type parameterStore struct {
 	task.Base     `yaml:",inline" json:",inline"`
-	SetParameters map[string]*jq.Query `yaml:"set,omitempty" json:"set,omitempty"`
-	GetParameters map[string]string    `yaml:"get,omitempty" json:"get,omitempty"`
-	Secure        bool                 `yaml:"secure,omitempty" json:"secure,omitempty"`
-	Overwrite     *bool                `yaml:"overwrite,omitempty" json:"overwrite,omitempty"`
-	client        *ssm.Client
+	SetParameters map[string]*jq.Query     `yaml:"set,omitempty" json:"set,omitempty"`
+	Lookup        map[string]config.String `yaml:"lookup,omitempty" json:"lookup,omitempty"`
+	CacheTTL      duration.Duration        `yaml:"cache_ttl,omitempty" json:"cache_ttl,omitempty"`
+	OnMissing     onMissingBehavior        `yaml:"on_missing,omitempty" json:"on_missing,omitempty"`
+	Secure        bool                     `yaml:"secure,omitempty" json:"secure,omitempty"`
+	Overwrite     *bool                    `yaml:"overwrite,omitempty" json:"overwrite,omitempty"`
+	client        ssmAPI
+	cache         map[string]cacheEntry
+	cacheMu       sync.RWMutex
 }
 
 func New() (task.Task, error) {
@@ -44,16 +78,47 @@ func (p *parameterStore) GetTaskConcurrency() int {
 }
 
 func (p *parameterStore) Init() error {
-	awsConfig, err := config.LoadDefaultConfig(ctx)
+
+	if len(p.SetParameters) > 0 && len(p.Lookup) > 0 {
+		return errBothModes
+	}
+
+	if len(p.SetParameters) == 0 && len(p.Lookup) == 0 {
+		return errNoMode
+	}
+
+	if p.OnMissing == `` {
+		p.OnMissing = onMissingError
+	}
+
+	if p.OnMissing != onMissingError && p.OnMissing != onMissingSkip {
+		return fmt.Errorf("invalid on_missing value %q: must be %q or %q", p.OnMissing, onMissingError, onMissingSkip)
+	}
+
+	if p.CacheTTL == 0 && len(p.Lookup) > 0 {
+		p.CacheTTL = duration.Duration(defaultCacheTTL)
+	}
+
+	if len(p.Lookup) > 0 {
+		p.cache = make(map[string]cacheEntry)
+	}
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
 	if err != nil {
 		return err
 	}
 
-	p.client = ssm.NewFromConfig(awsConfig)
+	p.client = ssm.NewFromConfig(cfg)
 	return nil
 }
 
-func (p *parameterStore) Run(input <-chan *record.Record, output chan<- *record.Record) (err error) {
+func (p *parameterStore) Run(input <-chan *record.Record, output chan<- *record.Record) error {
+
+	// GetRecord treats a nil channel as an immediately closed one, so without this
+	// a source-positioned task would exit successfully having done nothing
+	if input == nil {
+		return errInputRequired
+	}
 
 	for {
 		r, ok := p.GetRecord(input)
@@ -61,38 +126,149 @@ func (p *parameterStore) Run(input <-chan *record.Record, output chan<- *record.
 			break
 		}
 
-		// first let's set parameters
-		for parameterName, parameterQuery := range p.SetParameters {
-			parameterValue, err := parameterQuery.Execute(r.Data)
-			if err != nil {
-				return err
-			}
+		var err error
+		if len(p.Lookup) > 0 {
+			err = p.lookupParameters(r)
+		} else {
+			err = p.setParameters(r)
+		}
 
-			parameterValueString, isString := parameterValue.(string)
-			if !isString {
-				return fmt.Errorf("%s parameter value is not string", parameterName)
+		if err != nil {
+			// a missing parameter is the one failure the pipeline author can route,
+			// so a single misconfigured tenant need not stop every other one
+			if errors.Is(err, errParameterNotFound) && p.OnMissing == onMissingSkip {
+				fmt.Printf("WARN: skipping record: %s\n", err)
+				continue
 			}
+			return err
+		}
 
-			putParameterInput := &ssm.PutParameterInput{
-				Name:      aws.String(parameterName),
-				Value:     aws.String(parameterValueString),
-				Overwrite: p.Overwrite,
-			}
+		p.SendRecord(r, output)
+	}
 
-			if p.Secure {
-				putParameterInput.Type = types.ParameterTypeSecureString
-			}
+	return nil
 
-			if _, err := p.client.PutParameter(ctx, putParameterInput); err != nil {
-				return err
-			}
+}
 
-			if output != nil {
-				p.SendRecord(r, output)
-			}
+func (p *parameterStore) setParameters(r *record.Record) error {
+
+	for name, query := range p.SetParameters {
+		result, err := query.Execute(r.Data)
+		if err != nil {
+			return err
+		}
+
+		value, ok := result.(string)
+		if !ok {
+			return fmt.Errorf("%s parameter value is not string", name)
+		}
+
+		if err := p.putParameter(name, value); err != nil {
+			return err
 		}
 	}
 
 	return nil
 
+}
+
+func (p *parameterStore) putParameter(name, value string) error {
+
+	input := &ssm.PutParameterInput{
+		Name:      aws.String(name),
+		Value:     aws.String(value),
+		Overwrite: p.Overwrite,
+	}
+
+	if p.Secure {
+		input.Type = types.ParameterTypeSecureString
+	}
+
+	_, err := p.client.PutParameter(ctx, input)
+
+	return err
+
+}
+
+func (p *parameterStore) lookupParameters(r *record.Record) error {
+
+	for key, path := range p.Lookup {
+		name, err := path.Get(r)
+		if err != nil {
+			return err
+		}
+
+		value, err := p.getParameter(name)
+		if err != nil {
+			return err
+		}
+
+		r.SetContextValue(key, value)
+	}
+
+	return nil
+
+}
+
+func (p *parameterStore) getParameter(name string) (string, error) {
+
+	if cached, ok := p.getCached(name); ok {
+		return cached, nil
+	}
+
+	out, err := p.client.GetParameter(ctx, &ssm.GetParameterInput{
+		Name:           aws.String(name),
+		WithDecryption: awsTrue,
+	})
+	if err != nil {
+		var notFound *types.ParameterNotFound
+		if errors.As(err, &notFound) {
+			return ``, fmt.Errorf("%w: %s", errParameterNotFound, name)
+		}
+		return ``, err
+	}
+
+	if out == nil || out.Parameter == nil || out.Parameter.Value == nil {
+		return ``, fmt.Errorf("%w: %s", errParameterNotFound, name)
+	}
+
+	value := *out.Parameter.Value
+	p.setCached(name, value)
+
+	return value, nil
+
+}
+
+func (p *parameterStore) getCached(name string) (string, bool) {
+	if time.Duration(p.CacheTTL) == 0 {
+		return ``, false
+	}
+
+	p.cacheMu.RLock()
+	defer p.cacheMu.RUnlock()
+
+	entry, ok := p.cache[name]
+	if !ok {
+		return ``, false
+	}
+
+	if time.Since(entry.fetchedAt) > time.Duration(p.CacheTTL) {
+		return ``, false
+	}
+
+	return entry.value, true
+}
+
+func (p *parameterStore) setCached(name, value string) {
+	if time.Duration(p.CacheTTL) == 0 {
+		return
+	}
+
+	p.cacheMu.Lock()
+	defer p.cacheMu.Unlock()
+
+	p.cache[name] = cacheEntry{
+		value:     value,
+		fetchedAt: time.Now(),
+	}
 }

--- a/internal/pkg/pipeline/task/http/http.go
+++ b/internal/pkg/pipeline/task/http/http.go
@@ -34,23 +34,6 @@ var (
 	ctx = context.Background()
 )
 
-type oauth struct {
-	ConsumerKey     string   `yaml:"consumer_key" json:"consumer_key"`
-	ConsumerSecret  string   `yaml:"consumer_secret" json:"consumer_secret"`
-	Token           string   `yaml:"token" json:"token"`
-	TokenSecret     string   `yaml:"token_secret" json:"token_secret"`
-	Version         string   `yaml:"version,omitempty" json:"version,omitempty"`
-	SignatureMethod string   `yaml:"signature_method,omitempty" json:"signature_method,omitempty"`
-	Realm           string   `yaml:"realm,omitempty" json:"realm,omitempty"`
-	PrivateKey      string   `yaml:"private_key,omitempty" json:"private_key,omitempty"`
-	Subject         string   `yaml:"subject,omitempty" json:"subject,omitempty"`
-	Issuer          string   `yaml:"issuer,omitempty" json:"issuer,omitempty"`
-	Audience        string   `yaml:"audience,omitempty" json:"audience,omitempty"`
-	TokenURI        string   `yaml:"token_uri,omitempty" json:"token_uri,omitempty"`
-	GrantType       string   `yaml:"grant_type,omitempty" json:"grant_type,omitempty"`
-	Scope           []string `yaml:"scope,omitempty" json:"scope,omitempty"`
-}
-
 type httpCore struct {
 	task.Base        `yaml:",inline" json:",inline"`
 	Method           string            `yaml:"method,omitempty" json:"method,omitempty"`
@@ -118,7 +101,7 @@ func (h *httpCore) newFromInput(data []byte) (*httpCore, error) {
 		ExpectedStatuses: h.ExpectedStatuses,
 		Body:             h.Body,
 		NextPage:         h.NextPage,
-		Oauth:            h.Oauth,
+		Oauth:            h.Oauth.copy(),
 		Proxy:            h.Proxy,
 		Timeout:          h.Timeout,
 		MaxRetries:       h.MaxRetries,
@@ -126,7 +109,7 @@ func (h *httpCore) newFromInput(data []byte) (*httpCore, error) {
 	}
 
 	if err := json.Unmarshal(data, newHttp); err != nil {
-		return nil, fmt.Errorf("cannot parse http payload [%s]: %s", err, string(data))
+		return nil, fmt.Errorf("cannot parse http payload: %w", err)
 	}
 
 	// we only append headers that are present in the current task (h) and missing in the new one
@@ -191,7 +174,7 @@ func (h *httpCore) processItem(rc *record.Record, output chan<- *record.Record) 
 
 	// we have infinite loop to account for potential pagination
 	for {
-		result, err := h.call(endpoint)
+		result, err := h.call(endpoint, rc)
 
 		if err != nil {
 			return err
@@ -288,7 +271,7 @@ func (h *httpCore) processItem(rc *record.Record, output chan<- *record.Record) 
 
 }
 
-func (h *httpCore) call(endpoint string) (*result, error) {
+func (h *httpCore) call(endpoint string, rc *record.Record) (*result, error) {
 
 	var lastErr error
 	for attempt := 1; attempt <= h.MaxRetries; attempt++ {
@@ -310,14 +293,7 @@ func (h *httpCore) call(endpoint string) (*result, error) {
 
 		// TODO: support multiple "behaviors" for oauth support
 		if h.Oauth != nil {
-			// apply default values if version and hash method are missing
-			if h.Oauth.Version == `` {
-				h.Oauth.Version = defaultOAuthVersion
-			}
-			if h.Oauth.SignatureMethod == `` {
-				h.Oauth.SignatureMethod = defaultSignatureMethod
-			}
-			if err := h.oauth(endpoint, request); err != nil {
+			if err := h.oauth(endpoint, request, rc); err != nil {
 				lastErr = err
 				if attempt < h.MaxRetries {
 					continue

--- a/internal/pkg/pipeline/task/http/oauth.go
+++ b/internal/pkg/pipeline/task/http/oauth.go
@@ -3,24 +3,30 @@ package http
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/patterninc/caterpillar/internal/pkg/pipeline/record"
 )
 
 const (
 	headerAuthorization = `Authorization`
 )
 
-func (h *httpCore) oauth(endpoint string, r *http.Request) error {
+func (h *httpCore) oauth(endpoint string, r *http.Request, rc *record.Record) error {
 
-	// let's choose the behavior
-	behavior, found := map[string]func(string, *http.Request) error{
-		`1.0`: h.oauth1,
-		`2.0`: h.oauth2,
-	}[h.Oauth.Version]
-
-	if !found {
-		return fmt.Errorf("unsupported oauth behavior: %v", h.Oauth.Version)
+	resolved, err := h.Oauth.resolve(rc)
+	if err != nil {
+		return err
 	}
 
-	return behavior(endpoint, r)
+	behavior, found := map[string]func(string, *http.Request, *resolvedOAuth) error{
+		`1.0`: h.oauth1,
+		`2.0`: h.oauth2,
+	}[resolved.Version]
+
+	if !found {
+		return fmt.Errorf("unsupported oauth behavior: %v", resolved.Version)
+	}
+
+	return behavior(endpoint, r, resolved)
 
 }

--- a/internal/pkg/pipeline/task/http/oauth1.go
+++ b/internal/pkg/pipeline/task/http/oauth1.go
@@ -63,7 +63,7 @@ func shouldEscape(c byte) bool {
 	return true
 }
 
-func (h *httpCore) oauth1(endpoint string, r *http.Request) (err error) {
+func (h *httpCore) oauth1(endpoint string, r *http.Request, oauth *resolvedOAuth) (err error) {
 
 	// let's parse the endpoint we got to...
 	parsedURL, err := url.Parse(endpoint)
@@ -81,11 +81,11 @@ func (h *httpCore) oauth1(endpoint string, r *http.Request) (err error) {
 
 	// set oauth parameters
 	oauthParameters := map[string]string{
-		`oauth_consumer_key`:     h.Oauth.ConsumerKey,
-		`oauth_signature_method`: h.Oauth.SignatureMethod,
+		`oauth_consumer_key`:     oauth.ConsumerKey,
+		`oauth_signature_method`: oauth.SignatureMethod,
 		`oauth_timestamp`:        fmt.Sprintf("%d", time.Now().Unix()),
-		`oauth_token`:            h.Oauth.Token,
-		`oauth_version`:          h.Oauth.Version,
+		`oauth_token`:            oauth.Token,
+		`oauth_version`:          oauth.Version,
 	}
 
 	if oauthParameters[`oauth_nonce`], err = getNonce(); err != nil {
@@ -108,12 +108,12 @@ func (h *httpCore) oauth1(endpoint string, r *http.Request) (err error) {
 	sort.Strings(parameters)
 
 	baseString := strings.Join([]string{h.Method, percentEncode(parsedURL.String()), percentEncode(strings.Join(parameters, `&`))}, "&")
-	signature := url.QueryEscape(sha256Hash(baseString, h.Oauth.ConsumerSecret+`&`+h.Oauth.TokenSecret))
+	signature := url.QueryEscape(sha256Hash(baseString, oauth.ConsumerSecret+`&`+oauth.TokenSecret))
 
 	// generate authorization header value
 	authorizationParts = append(authorizationParts, fmt.Sprintf("%s=%q", `oauth_signature`, signature))
-	if h.Oauth.Realm != `` {
-		authorizationParts = append(authorizationParts, fmt.Sprintf("%s=%q", `realm`, h.Oauth.Realm))
+	if oauth.Realm != `` {
+		authorizationParts = append(authorizationParts, fmt.Sprintf("%s=%q", `realm`, oauth.Realm))
 	}
 	r.Header.Set(headerAuthorization, fmt.Sprintf("OAuth %s", strings.Join(authorizationParts, `,`)))
 

--- a/internal/pkg/pipeline/task/http/oauth2.go
+++ b/internal/pkg/pipeline/task/http/oauth2.go
@@ -22,14 +22,14 @@ const (
 	contentTypeForm = `application/x-www-form-urlencoded`
 )
 
-func (h *httpCore) oauth2(endpoint string, r *http.Request) error {
+func (h *httpCore) oauth2(endpoint string, r *http.Request, oauth *resolvedOAuth) error {
 
-	jwt, err := h.getJWT()
+	jwt, err := getJWT(oauth)
 	if err != nil {
 		return err
 	}
 
-	accessToken, err := h.getOauthToken(jwt)
+	accessToken, err := getOauthToken(oauth, jwt)
 	if err != nil {
 		return err
 	}
@@ -40,23 +40,22 @@ func (h *httpCore) oauth2(endpoint string, r *http.Request) error {
 
 }
 
-func (h *httpCore) getJWT() (string, error) {
+func getJWT(oauth *resolvedOAuth) (string, error) {
 
 	now := time.Now().Unix()
 
 	claims := jwt.MapClaims{
-		"iss":   h.Oauth.Issuer,
-		"sub":   h.Oauth.Subject,
-		"aud":   h.Oauth.Audience,
+		"iss":   oauth.Issuer,
+		"sub":   oauth.Subject,
+		"aud":   oauth.Audience,
 		"iat":   now,
 		"exp":   now + jwtExpiration,
-		"scope": strings.Join(h.Oauth.Scope, " "),
+		"scope": strings.Join(oauth.Scope, " "),
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 
-	// parse private key
-	key, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(h.Oauth.PrivateKey))
+	key, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(oauth.PrivateKey))
 	if err != nil {
 		return ``, err
 	}
@@ -65,14 +64,14 @@ func (h *httpCore) getJWT() (string, error) {
 
 }
 
-func (h *httpCore) getOauthToken(jwt string) (string, error) {
+func getOauthToken(oauth *resolvedOAuth, jwt string) (string, error) {
 
 	data := url.Values{}
 	data.Set(assertionKey, jwt)
-	data.Set(grantTypeKey, h.Oauth.GrantType)
+	data.Set(grantTypeKey, oauth.GrantType)
 	payload := strings.NewReader(data.Encode())
 
-	req, err := http.NewRequest(http.MethodPost, h.Oauth.TokenURI, payload)
+	req, err := http.NewRequest(http.MethodPost, oauth.TokenURI, payload)
 	if err != nil {
 		return ``, err
 	}
@@ -91,11 +90,20 @@ func (h *httpCore) getOauthToken(jwt string) (string, error) {
 		return ``, err
 	}
 
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return ``, fmt.Errorf("oauth token request failed with status %d", resp.StatusCode)
+	}
+
 	var accessTokenResp map[string]interface{}
 	if err = json.Unmarshal(body, &accessTokenResp); err != nil {
 		return ``, err
 	}
 
-	return accessTokenResp[accessTokenKey].(string), nil
+	accessToken, ok := accessTokenResp[accessTokenKey].(string)
+	if !ok || accessToken == `` {
+		return ``, fmt.Errorf("oauth token response missing access_token")
+	}
+
+	return accessToken, nil
 
 }

--- a/internal/pkg/pipeline/task/http/oauth_resolve.go
+++ b/internal/pkg/pipeline/task/http/oauth_resolve.go
@@ -1,0 +1,158 @@
+package http
+
+import (
+	"github.com/patterninc/caterpillar/internal/pkg/config"
+	"github.com/patterninc/caterpillar/internal/pkg/pipeline/record"
+)
+
+type oauth struct {
+	ConsumerKey     config.String   `yaml:"consumer_key" json:"consumer_key"`
+	ConsumerSecret  config.String   `yaml:"consumer_secret" json:"consumer_secret"`
+	Token           config.String   `yaml:"token" json:"token"`
+	TokenSecret     config.String   `yaml:"token_secret" json:"token_secret"`
+	Version         config.String   `yaml:"version,omitempty" json:"version,omitempty"`
+	SignatureMethod config.String   `yaml:"signature_method,omitempty" json:"signature_method,omitempty"`
+	Realm           config.String   `yaml:"realm,omitempty" json:"realm,omitempty"`
+	PrivateKey      config.String   `yaml:"private_key,omitempty" json:"private_key,omitempty"`
+	Subject         config.String   `yaml:"subject,omitempty" json:"subject,omitempty"`
+	Issuer          config.String   `yaml:"issuer,omitempty" json:"issuer,omitempty"`
+	Audience        config.String   `yaml:"audience,omitempty" json:"audience,omitempty"`
+	TokenURI        config.String   `yaml:"token_uri,omitempty" json:"token_uri,omitempty"`
+	GrantType       config.String   `yaml:"grant_type,omitempty" json:"grant_type,omitempty"`
+	Scope           []config.String `yaml:"scope,omitempty" json:"scope,omitempty"`
+}
+
+type resolvedOAuth struct {
+	ConsumerKey     string
+	ConsumerSecret  string
+	Token           string
+	TokenSecret     string
+	Version         string
+	SignatureMethod string
+	Realm           string
+	PrivateKey      string
+	Subject         string
+	Issuer          string
+	Audience        string
+	TokenURI        string
+	GrantType       string
+	Scope           []string
+}
+
+func (o *oauth) copy() *oauth {
+	if o == nil {
+		return nil
+	}
+
+	cp := *o
+	if len(o.Scope) > 0 {
+		cp.Scope = append([]config.String(nil), o.Scope...)
+	}
+
+	return &cp
+}
+
+func (o *oauth) resolve(r *record.Record) (*resolvedOAuth, error) {
+	if o == nil {
+		return nil, nil
+	}
+
+	version, err := o.Version.Get(r)
+	if err != nil {
+		return nil, err
+	}
+	if version == `` {
+		version = defaultOAuthVersion
+	}
+
+	signatureMethod, err := o.SignatureMethod.Get(r)
+	if err != nil {
+		return nil, err
+	}
+	if signatureMethod == `` {
+		signatureMethod = defaultSignatureMethod
+	}
+
+	consumerKey, err := o.ConsumerKey.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	consumerSecret, err := o.ConsumerSecret.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := o.Token.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenSecret, err := o.TokenSecret.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	realm, err := o.Realm.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey, err := o.PrivateKey.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	subject, err := o.Subject.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	issuer, err := o.Issuer.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	audience, err := o.Audience.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenURI, err := o.TokenURI.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	grantType, err := o.GrantType.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	scope := make([]string, 0, len(o.Scope))
+	for _, scopeValue := range o.Scope {
+		resolved, err := scopeValue.Get(r)
+		if err != nil {
+			return nil, err
+		}
+		if resolved != `` {
+			scope = append(scope, resolved)
+		}
+	}
+
+	return &resolvedOAuth{
+		ConsumerKey:     consumerKey,
+		ConsumerSecret:  consumerSecret,
+		Token:           token,
+		TokenSecret:     tokenSecret,
+		Version:         version,
+		SignatureMethod: signatureMethod,
+		Realm:           realm,
+		PrivateKey:      privateKey,
+		Subject:         subject,
+		Issuer:          issuer,
+		Audience:        audience,
+		TokenURI:        tokenURI,
+		GrantType:       grantType,
+		Scope:           scope,
+	}, nil
+}


### PR DESCRIPTION
Part 1 of 2. #93 builds on this.

## Why

A pipeline that serves many tenants needs a different secret per record. Parameter
paths were fixed at config load, so the only way to reach a second tenant's
credentials was a second copy of the pipeline.

## What

Adds a `lookup:` mode to `aws_parameter_store` whose paths are `config.String`, so
they can carry `{{ context "..." }}` and resolve per record. Fetched values land in
record **context**, not data, because data flows on into sinks and error messages
and these values are usually credentials.

```yaml
- name: fetch_credentials
  type: aws_parameter_store
  lookup:
    client_email: /caterpillar/kms/accounts/{{ context "slug" }}/client_email
    private_key: /caterpillar/kms/accounts/{{ context "slug" }}/private_key
  cache_ttl: 5m
  on_missing: skip
```

Notable decisions:

- **Cache is keyed on the resolved path**, not the template. Keying on the template
  would collapse every tenant onto one entry and hand one account's secret to another.
- **Only hits are cached.** A missing parameter is re-checked every record, so creating
  it takes effect without waiting out a TTL.
- `cache_ttl` defaults to `5m`; `0` disables caching.
- `on_missing` is `error` (default) or `skip`, and applies per record rather than
  failing the pipeline.
- **Removes the `get:` mode**, which the README documented but no code implemented.
- An input channel is now required, since both remaining modes are record-driven.

## Testing

`go build ./...` and `go vet` pass on the touched packages. Behavior was exercised by
running the pipeline against SSM; unit tests were left out of this PR by request.