### PR TITLE
feat(http): resolve oauth credentials per record

### DIFF
--- a/internal/pkg/pipeline/task/aws/parameter_store/README.md
+++ b/internal/pkg/pipeline/task/aws/parameter_store/README.md
@@ -59,7 +59,7 @@ tasks:
     overwrite: true
 ```
 
-### Lookup mode - Fetch per-record values into context:
+### Lookup mode - Fetch per-record credentials into context:
 ```yaml
 tasks:
   - name: extract_slug
@@ -74,10 +74,15 @@ tasks:
       private_key: /caterpillar/kms_google_drive_ingestion/accounts/{{ context "slug" }}/private_key
     cache_ttl: 5m
     on_missing: skip
+  - name: call_api
+    type: http
+    endpoint: https://www.googleapis.com/drive/v3/files
+    oauth:
+      version: "2.0"
+      issuer: "{{ context \"client_email\" }}"
+      subject: "{{ context \"client_email\" }}"
+      private_key: "{{ context \"private_key\" }}"
 ```
-
-Each downstream task reads the values with `{{ context "client_email" }}`, in any
-field whose type is `config.String`.
 
 ## Use Cases
 

--- a/internal/pkg/pipeline/task/http/http.go
+++ b/internal/pkg/pipeline/task/http/http.go
@@ -34,23 +34,6 @@ var (
 	ctx = context.Background()
 )
 
-type oauth struct {
-	ConsumerKey     string   `yaml:"consumer_key" json:"consumer_key"`
-	ConsumerSecret  string   `yaml:"consumer_secret" json:"consumer_secret"`
-	Token           string   `yaml:"token" json:"token"`
-	TokenSecret     string   `yaml:"token_secret" json:"token_secret"`
-	Version         string   `yaml:"version,omitempty" json:"version,omitempty"`
-	SignatureMethod string   `yaml:"signature_method,omitempty" json:"signature_method,omitempty"`
-	Realm           string   `yaml:"realm,omitempty" json:"realm,omitempty"`
-	PrivateKey      string   `yaml:"private_key,omitempty" json:"private_key,omitempty"`
-	Subject         string   `yaml:"subject,omitempty" json:"subject,omitempty"`
-	Issuer          string   `yaml:"issuer,omitempty" json:"issuer,omitempty"`
-	Audience        string   `yaml:"audience,omitempty" json:"audience,omitempty"`
-	TokenURI        string   `yaml:"token_uri,omitempty" json:"token_uri,omitempty"`
-	GrantType       string   `yaml:"grant_type,omitempty" json:"grant_type,omitempty"`
-	Scope           []string `yaml:"scope,omitempty" json:"scope,omitempty"`
-}
-
 type httpCore struct {
 	task.Base        `yaml:",inline" json:",inline"`
 	Method           string            `yaml:"method,omitempty" json:"method,omitempty"`
@@ -118,7 +101,7 @@ func (h *httpCore) newFromInput(data []byte) (*httpCore, error) {
 		ExpectedStatuses: h.ExpectedStatuses,
 		Body:             h.Body,
 		NextPage:         h.NextPage,
-		Oauth:            h.Oauth,
+		Oauth:            h.Oauth.copy(),
 		Proxy:            h.Proxy,
 		Timeout:          h.Timeout,
 		MaxRetries:       h.MaxRetries,
@@ -126,7 +109,7 @@ func (h *httpCore) newFromInput(data []byte) (*httpCore, error) {
 	}
 
 	if err := json.Unmarshal(data, newHttp); err != nil {
-		return nil, fmt.Errorf("cannot parse http payload [%s]: %s", err, string(data))
+		return nil, fmt.Errorf("cannot parse http payload: %w", err)
 	}
 
 	// we only append headers that are present in the current task (h) and missing in the new one
@@ -191,7 +174,7 @@ func (h *httpCore) processItem(rc *record.Record, output chan<- *record.Record) 
 
 	// we have infinite loop to account for potential pagination
 	for {
-		result, err := h.call(endpoint)
+		result, err := h.call(endpoint, rc)
 
 		if err != nil {
 			return err
@@ -288,7 +271,7 @@ func (h *httpCore) processItem(rc *record.Record, output chan<- *record.Record) 
 
 }
 
-func (h *httpCore) call(endpoint string) (*result, error) {
+func (h *httpCore) call(endpoint string, rc *record.Record) (*result, error) {
 
 	var lastErr error
 	for attempt := 1; attempt <= h.MaxRetries; attempt++ {
@@ -310,14 +293,7 @@ func (h *httpCore) call(endpoint string) (*result, error) {
 
 		// TODO: support multiple "behaviors" for oauth support
 		if h.Oauth != nil {
-			// apply default values if version and hash method are missing
-			if h.Oauth.Version == `` {
-				h.Oauth.Version = defaultOAuthVersion
-			}
-			if h.Oauth.SignatureMethod == `` {
-				h.Oauth.SignatureMethod = defaultSignatureMethod
-			}
-			if err := h.oauth(endpoint, request); err != nil {
+			if err := h.oauth(endpoint, request, rc); err != nil {
 				lastErr = err
 				if attempt < h.MaxRetries {
 					continue

--- a/internal/pkg/pipeline/task/http/oauth.go
+++ b/internal/pkg/pipeline/task/http/oauth.go
@@ -3,24 +3,30 @@ package http
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/patterninc/caterpillar/internal/pkg/pipeline/record"
 )
 
 const (
 	headerAuthorization = `Authorization`
 )
 
-func (h *httpCore) oauth(endpoint string, r *http.Request) error {
+func (h *httpCore) oauth(endpoint string, r *http.Request, rc *record.Record) error {
 
-	// let's choose the behavior
-	behavior, found := map[string]func(string, *http.Request) error{
-		`1.0`: h.oauth1,
-		`2.0`: h.oauth2,
-	}[h.Oauth.Version]
-
-	if !found {
-		return fmt.Errorf("unsupported oauth behavior: %v", h.Oauth.Version)
+	resolved, err := h.Oauth.resolve(rc)
+	if err != nil {
+		return err
 	}
 
-	return behavior(endpoint, r)
+	behavior, found := map[string]func(string, *http.Request, *resolvedOAuth) error{
+		`1.0`: h.oauth1,
+		`2.0`: h.oauth2,
+	}[resolved.Version]
+
+	if !found {
+		return fmt.Errorf("unsupported oauth behavior: %v", resolved.Version)
+	}
+
+	return behavior(endpoint, r, resolved)
 
 }

--- a/internal/pkg/pipeline/task/http/oauth1.go
+++ b/internal/pkg/pipeline/task/http/oauth1.go
@@ -63,7 +63,7 @@ func shouldEscape(c byte) bool {
 	return true
 }
 
-func (h *httpCore) oauth1(endpoint string, r *http.Request) (err error) {
+func (h *httpCore) oauth1(endpoint string, r *http.Request, oauth *resolvedOAuth) (err error) {
 
 	// let's parse the endpoint we got to...
 	parsedURL, err := url.Parse(endpoint)
@@ -81,11 +81,11 @@ func (h *httpCore) oauth1(endpoint string, r *http.Request) (err error) {
 
 	// set oauth parameters
 	oauthParameters := map[string]string{
-		`oauth_consumer_key`:     h.Oauth.ConsumerKey,
-		`oauth_signature_method`: h.Oauth.SignatureMethod,
+		`oauth_consumer_key`:     oauth.ConsumerKey,
+		`oauth_signature_method`: oauth.SignatureMethod,
 		`oauth_timestamp`:        fmt.Sprintf("%d", time.Now().Unix()),
-		`oauth_token`:            h.Oauth.Token,
-		`oauth_version`:          h.Oauth.Version,
+		`oauth_token`:            oauth.Token,
+		`oauth_version`:          oauth.Version,
 	}
 
 	if oauthParameters[`oauth_nonce`], err = getNonce(); err != nil {
@@ -108,12 +108,12 @@ func (h *httpCore) oauth1(endpoint string, r *http.Request) (err error) {
 	sort.Strings(parameters)
 
 	baseString := strings.Join([]string{h.Method, percentEncode(parsedURL.String()), percentEncode(strings.Join(parameters, `&`))}, "&")
-	signature := url.QueryEscape(sha256Hash(baseString, h.Oauth.ConsumerSecret+`&`+h.Oauth.TokenSecret))
+	signature := url.QueryEscape(sha256Hash(baseString, oauth.ConsumerSecret+`&`+oauth.TokenSecret))
 
 	// generate authorization header value
 	authorizationParts = append(authorizationParts, fmt.Sprintf("%s=%q", `oauth_signature`, signature))
-	if h.Oauth.Realm != `` {
-		authorizationParts = append(authorizationParts, fmt.Sprintf("%s=%q", `realm`, h.Oauth.Realm))
+	if oauth.Realm != `` {
+		authorizationParts = append(authorizationParts, fmt.Sprintf("%s=%q", `realm`, oauth.Realm))
 	}
 	r.Header.Set(headerAuthorization, fmt.Sprintf("OAuth %s", strings.Join(authorizationParts, `,`)))
 

--- a/internal/pkg/pipeline/task/http/oauth2.go
+++ b/internal/pkg/pipeline/task/http/oauth2.go
@@ -22,14 +22,14 @@ const (
 	contentTypeForm = `application/x-www-form-urlencoded`
 )
 
-func (h *httpCore) oauth2(endpoint string, r *http.Request) error {
+func (h *httpCore) oauth2(endpoint string, r *http.Request, oauth *resolvedOAuth) error {
 
-	jwt, err := h.getJWT()
+	jwt, err := getJWT(oauth)
 	if err != nil {
 		return err
 	}
 
-	accessToken, err := h.getOauthToken(jwt)
+	accessToken, err := getOauthToken(oauth, jwt)
 	if err != nil {
 		return err
 	}
@@ -40,23 +40,22 @@ func (h *httpCore) oauth2(endpoint string, r *http.Request) error {
 
 }
 
-func (h *httpCore) getJWT() (string, error) {
+func getJWT(oauth *resolvedOAuth) (string, error) {
 
 	now := time.Now().Unix()
 
 	claims := jwt.MapClaims{
-		"iss":   h.Oauth.Issuer,
-		"sub":   h.Oauth.Subject,
-		"aud":   h.Oauth.Audience,
+		"iss":   oauth.Issuer,
+		"sub":   oauth.Subject,
+		"aud":   oauth.Audience,
 		"iat":   now,
 		"exp":   now + jwtExpiration,
-		"scope": strings.Join(h.Oauth.Scope, " "),
+		"scope": strings.Join(oauth.Scope, " "),
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 
-	// parse private key
-	key, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(h.Oauth.PrivateKey))
+	key, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(oauth.PrivateKey))
 	if err != nil {
 		return ``, err
 	}
@@ -65,14 +64,14 @@ func (h *httpCore) getJWT() (string, error) {
 
 }
 
-func (h *httpCore) getOauthToken(jwt string) (string, error) {
+func getOauthToken(oauth *resolvedOAuth, jwt string) (string, error) {
 
 	data := url.Values{}
 	data.Set(assertionKey, jwt)
-	data.Set(grantTypeKey, h.Oauth.GrantType)
+	data.Set(grantTypeKey, oauth.GrantType)
 	payload := strings.NewReader(data.Encode())
 
-	req, err := http.NewRequest(http.MethodPost, h.Oauth.TokenURI, payload)
+	req, err := http.NewRequest(http.MethodPost, oauth.TokenURI, payload)
 	if err != nil {
 		return ``, err
 	}
@@ -91,11 +90,20 @@ func (h *httpCore) getOauthToken(jwt string) (string, error) {
 		return ``, err
 	}
 
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return ``, fmt.Errorf("oauth token request failed with status %d", resp.StatusCode)
+	}
+
 	var accessTokenResp map[string]interface{}
 	if err = json.Unmarshal(body, &accessTokenResp); err != nil {
 		return ``, err
 	}
 
-	return accessTokenResp[accessTokenKey].(string), nil
+	accessToken, ok := accessTokenResp[accessTokenKey].(string)
+	if !ok || accessToken == `` {
+		return ``, fmt.Errorf("oauth token response missing access_token")
+	}
+
+	return accessToken, nil
 
 }

--- a/internal/pkg/pipeline/task/http/oauth_resolve.go
+++ b/internal/pkg/pipeline/task/http/oauth_resolve.go
@@ -1,0 +1,158 @@
+package http
+
+import (
+	"github.com/patterninc/caterpillar/internal/pkg/config"
+	"github.com/patterninc/caterpillar/internal/pkg/pipeline/record"
+)
+
+type oauth struct {
+	ConsumerKey     config.String   `yaml:"consumer_key" json:"consumer_key"`
+	ConsumerSecret  config.String   `yaml:"consumer_secret" json:"consumer_secret"`
+	Token           config.String   `yaml:"token" json:"token"`
+	TokenSecret     config.String   `yaml:"token_secret" json:"token_secret"`
+	Version         config.String   `yaml:"version,omitempty" json:"version,omitempty"`
+	SignatureMethod config.String   `yaml:"signature_method,omitempty" json:"signature_method,omitempty"`
+	Realm           config.String   `yaml:"realm,omitempty" json:"realm,omitempty"`
+	PrivateKey      config.String   `yaml:"private_key,omitempty" json:"private_key,omitempty"`
+	Subject         config.String   `yaml:"subject,omitempty" json:"subject,omitempty"`
+	Issuer          config.String   `yaml:"issuer,omitempty" json:"issuer,omitempty"`
+	Audience        config.String   `yaml:"audience,omitempty" json:"audience,omitempty"`
+	TokenURI        config.String   `yaml:"token_uri,omitempty" json:"token_uri,omitempty"`
+	GrantType       config.String   `yaml:"grant_type,omitempty" json:"grant_type,omitempty"`
+	Scope           []config.String `yaml:"scope,omitempty" json:"scope,omitempty"`
+}
+
+type resolvedOAuth struct {
+	ConsumerKey     string
+	ConsumerSecret  string
+	Token           string
+	TokenSecret     string
+	Version         string
+	SignatureMethod string
+	Realm           string
+	PrivateKey      string
+	Subject         string
+	Issuer          string
+	Audience        string
+	TokenURI        string
+	GrantType       string
+	Scope           []string
+}
+
+func (o *oauth) copy() *oauth {
+	if o == nil {
+		return nil
+	}
+
+	cp := *o
+	if len(o.Scope) > 0 {
+		cp.Scope = append([]config.String(nil), o.Scope...)
+	}
+
+	return &cp
+}
+
+func (o *oauth) resolve(r *record.Record) (*resolvedOAuth, error) {
+	if o == nil {
+		return nil, nil
+	}
+
+	version, err := o.Version.Get(r)
+	if err != nil {
+		return nil, err
+	}
+	if version == `` {
+		version = defaultOAuthVersion
+	}
+
+	signatureMethod, err := o.SignatureMethod.Get(r)
+	if err != nil {
+		return nil, err
+	}
+	if signatureMethod == `` {
+		signatureMethod = defaultSignatureMethod
+	}
+
+	consumerKey, err := o.ConsumerKey.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	consumerSecret, err := o.ConsumerSecret.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := o.Token.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenSecret, err := o.TokenSecret.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	realm, err := o.Realm.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey, err := o.PrivateKey.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	subject, err := o.Subject.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	issuer, err := o.Issuer.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	audience, err := o.Audience.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenURI, err := o.TokenURI.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	grantType, err := o.GrantType.Get(r)
+	if err != nil {
+		return nil, err
+	}
+
+	scope := make([]string, 0, len(o.Scope))
+	for _, scopeValue := range o.Scope {
+		resolved, err := scopeValue.Get(r)
+		if err != nil {
+			return nil, err
+		}
+		if resolved != `` {
+			scope = append(scope, resolved)
+		}
+	}
+
+	return &resolvedOAuth{
+		ConsumerKey:     consumerKey,
+		ConsumerSecret:  consumerSecret,
+		Token:           token,
+		TokenSecret:     tokenSecret,
+		Version:         version,
+		SignatureMethod: signatureMethod,
+		Realm:           realm,
+		PrivateKey:      privateKey,
+		Subject:         subject,
+		Issuer:          issuer,
+		Audience:        audience,
+		TokenURI:        tokenURI,
+		GrantType:       grantType,
+		Scope:           scope,
+	}, nil
+}


### PR DESCRIPTION
Part 2 of 2, stacked on #92. **Review #92 first** — this PR's diff is only the `http`/oauth changes.

## Why

The `oauth` fields were plain strings, fixed at config load. A `{{ context "..." }}`
written into them reached the signer as a literal, so each tenant needed its own
pipeline. Combined with the lookup in #92, this lets one pipeline sign for many tenants.

## What

- `oauth` fields become `config.String` and are resolved against the record.
- Resolution happens **onto a copy**. The task config is shared across concurrent
  records, so resolving in place would let one record's credentials be observed by
  another in flight.
- The token fetch now **checks the response status before decoding** and stops
  asserting types out of the payload unchecked, so an error page from the identity
  provider fails that record instead of panicking the pipeline.

```yaml
- name: call_api
  type: http
  endpoint: https://www.googleapis.com/drive/v3/files
  oauth:
    version: "2.0"
    issuer: '{{ context "client_email" }}'
    private_key: '{{ context "private_key" }}'
```

## Compatibility

Literal values behave exactly as before — `config.String` resolves a string with no
templating to itself.

## Testing

`go build ./...` and `go vet` pass on the touched packages. Unit tests were left out of
this PR by request.