### PR TITLE
docs: correct stale field names, defaults and dead links in task READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The system is particularly useful for:
 Caterpillar is built around the concept of **tasks** that process **records** in a pipeline. Here's how it works:
 
 1. **Records**: Each piece of data in the pipeline is wrapped in a `Record` object containing:
-   - `Data`: The actual data string
+   - `Data`: The actual data, as raw bytes
    - `Origin`: The name of the task that created this record
    - `ID`: A unique identifier for the record
    - `Context`: Additional metadata that can be shared between tasks
@@ -254,7 +254,7 @@ tasks:
 Caterpillar supports the following tasks, each of which can serve different roles depending on their configuration:
 
 - **`archive`** - [Pack and unpack archives (tar, zip)](https://github.com/patterninc/caterpillar/blob/main/internal/pkg/pipeline/task/archive/README.md)
-- **`aws_parameter_store`** - [Read parameters from AWS Systems Manager Parameter Store](https://github.com/patterninc/caterpillar/blob/main/internal/pkg/pipeline/task/aws/parameter_store/README.md)
+- **`aws_parameter_store`** - [Write to or look up parameters in AWS Systems Manager Parameter Store](https://github.com/patterninc/caterpillar/blob/main/internal/pkg/pipeline/task/aws/parameter_store/README.md)
 - **`compress`** - [Compress or decompress data using various algorithms](https://github.com/patterninc/caterpillar/blob/main/internal/pkg/pipeline/task/compress/README.md)
 - **`converter`** - [Convert data between different formats (CSV, HTML, JSON, XML, SST, Protobuf)](https://github.com/patterninc/caterpillar/blob/main/internal/pkg/pipeline/task/converter/README.md)
 - **`delay`** - [Add controlled delays between record processing](https://github.com/patterninc/caterpillar/blob/main/internal/pkg/pipeline/task/delay/README.md)

--- a/internal/pkg/pipeline/task/archive/README.md
+++ b/internal/pkg/pipeline/task/archive/README.md
@@ -18,6 +18,11 @@ The task receives records from its input channel, applies the archiving operatio
 
 During **unpack**, the sanitized base filename of each extracted entry is stored in the record context under the key `CATERPILLAR_ARCHIVE_FILE_NAME_WRITE`. The stem is lowercased with non-alphanumeric characters replaced by underscores, while the extension is preserved and lowercased (e.g. `"Report 1.CSV"` → `"report_1.csv"`).
 
+**Pack** requires every incoming record to already carry `CATERPILLAR_FILE_NAME_WRITE` in its
+context — that value becomes the entry's name inside the archive. A record without it aborts the
+process. A `file` read upstream sets the key for you; any other source has to set it via a
+`context:` block.
+
 ## Configuration Fields
 
 | Field | Type | Default | Description |
@@ -26,12 +31,18 @@ During **unpack**, the sanitized base filename of each extracted entry is stored
 | `type` | string | `archive` | Must be "archive" |
 | `format` | string | `zip` | Archive format (zip, tar) |
 | `action` | string | `pack` | Action type (pack or unpack) |
+| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
+| `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
+| `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
 
 ## Supported Formats
 
 The task supports the following archive formats:
 - **zip**: Standard ZIP format, widely compatible
 - **tar**: TAR format, commonly used in Unix/Linux environments
+
+An invalid `action` is rejected at config load. An unrecognized `format`, however, is not
+validated and panics at run time.
 
 ## Example Configurations
 

--- a/internal/pkg/pipeline/task/archive/README.md
+++ b/internal/pkg/pipeline/task/archive/README.md
@@ -19,9 +19,8 @@ The task receives records from its input channel, applies the archiving operatio
 During **unpack**, the sanitized base filename of each extracted entry is stored in the record context under the key `CATERPILLAR_ARCHIVE_FILE_NAME_WRITE`. The stem is lowercased with non-alphanumeric characters replaced by underscores, while the extension is preserved and lowercased (e.g. `"Report 1.CSV"` → `"report_1.csv"`).
 
 **Pack** requires every incoming record to already carry `CATERPILLAR_FILE_NAME_WRITE` in its
-context — that value becomes the entry's name inside the archive. A record without it aborts the
-process. A `file` read upstream sets the key for you; any other source has to set it via a
-`context:` block.
+context — that value becomes the entry's name inside the archive. A `file` read upstream sets
+the key for you; any other source has to set it via a `context:` block.
 
 ## Configuration Fields
 
@@ -40,9 +39,6 @@ process. A `file` read upstream sets the key for you; any other source has to se
 The task supports the following archive formats:
 - **zip**: Standard ZIP format, widely compatible
 - **tar**: TAR format, commonly used in Unix/Linux environments
-
-An invalid `action` is rejected at config load. An unrecognized `format`, however, is not
-validated and panics at run time.
 
 ## Example Configurations
 

--- a/internal/pkg/pipeline/task/aws/parameter_store/README.md
+++ b/internal/pkg/pipeline/task/aws/parameter_store/README.md
@@ -36,7 +36,7 @@ In lookup mode, each input record is forwarded after its context is populated. `
 | `type` | string | `aws_parameter_store` | Must be "aws_parameter_store" |
 | `set` | map[string]string | - | Parameters to set, keyed by parameter name, valued by a JQ expression over the record |
 | `lookup` | map[string]string | - | Parameters to retrieve per record, keyed by context field name, valued by parameter path |
-| `cache_ttl` | duration | `5m` | How long successful lookups are cached. Omitted or `0` uses `5m`. |
+| `cache_ttl` | duration | `5m` | How long successful lookups are cached. |
 | `on_missing` | string | `error` | Lookup-mode behaviour when a parameter does not exist: `error` stops the task; `skip` logs and drops the record |
 | `secure` | bool | `true` | Whether to store parameters as SecureString (write mode only) |
 | `overwrite` | bool | `true` | Whether to overwrite existing parameters (write mode only) |

--- a/internal/pkg/pipeline/task/aws/parameter_store/README.md
+++ b/internal/pkg/pipeline/task/aws/parameter_store/README.md
@@ -16,6 +16,8 @@ The task operates in two modes, selected by which field is configured:
 | Write | `set` | Sets the `set` parameters from each record, then forwards that record downstream unchanged |
 | Lookup | `lookup` | Fetches parameters whose paths may vary per record, writes values to record context, then forwards the record |
 
+Startup-time reads use the `{{ secret "/ssm/path" }}` template in any task field. `lookup` is the per-record path.
+
 ## Input Channel
 
 Accepts `*record.Record` objects. Lookup paths may reference record context via `{{ context "..." }}`.
@@ -32,15 +34,18 @@ In lookup mode, each input record is forwarded after its context is populated. `
 |-------|------|---------|-------------|
 | `name` | string | - | Task name for identification |
 | `type` | string | `aws_parameter_store` | Must be "aws_parameter_store" |
-| `set` | map[string]string | - | Parameters to set, keyed by parameter name, valued by JQ expression |
+| `set` | map[string]string | - | Parameters to set, keyed by parameter name, valued by a JQ expression over the record |
 | `lookup` | map[string]string | - | Parameters to retrieve per record, keyed by context field name, valued by parameter path |
-| `cache_ttl` | duration | `5m` | How long successful lookups are cached. `0` disables caching. |
-| `on_missing` | string | `error` | Behaviour when a parameter does not exist: `error` stops the task; `skip` logs and drops the record |
+| `cache_ttl` | duration | `5m` | How long successful lookups are cached. Omitted or `0` uses `5m`. |
+| `on_missing` | string | `error` | Lookup-mode behaviour when a parameter does not exist: `error` stops the task; `skip` logs and drops the record |
 | `secure` | bool | `true` | Whether to store parameters as SecureString (write mode only) |
-| `overwrite` | bool | `true` | Whether to overwrite existing parameters |
+| `overwrite` | bool | `true` | Whether to overwrite existing parameters (write mode only) |
+| `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
 
 Only successful lookups are cached. Missing parameters are never cached and always follow `on_missing`.
+
+`task_concurrency` is accepted but forced to 1, with a warning — a single SSM client runs.
 
 ## Example Configurations
 
@@ -66,22 +71,29 @@ tasks:
     type: jq
     path: .
     context:
-      slug: .channel_id
+      slug: .tenant_id
   - name: fetch_credentials
     type: aws_parameter_store
     lookup:
-      client_email: /caterpillar/kms_google_drive_ingestion/accounts/{{ context "slug" }}/client_email
-      private_key: /caterpillar/kms_google_drive_ingestion/accounts/{{ context "slug" }}/private_key
+      api_token: /prod/tenants/{{ context "slug" }}/api_token
+      api_secret: /prod/tenants/{{ context "slug" }}/api_secret
     cache_ttl: 5m
     on_missing: skip
   - name: call_api
     type: http
-    endpoint: https://www.googleapis.com/drive/v3/files
-    oauth:
-      version: "2.0"
-      issuer: "{{ context \"client_email\" }}"
-      subject: "{{ context \"client_email\" }}"
-      private_key: "{{ context \"private_key\" }}"
+    endpoint: https://api.example.com/data
+    headers:
+      Authorization: Bearer {{ context "api_token" }}
+```
+
+### Startup-time read (config template, not this task):
+```yaml
+tasks:
+  - name: call_api
+    type: http
+    endpoint: https://api.example.com/data
+    headers:
+      Authorization: Bearer {{ secret "/prod/api/token" }}
 ```
 
 ## Use Cases
@@ -92,3 +104,4 @@ tasks:
 - **Multi-tenant credentials**: Resolve per-tenant secrets from SSM at runtime
 - **Environment setup**: Configure different environments with different parameters
 - **Data persistence**: Store pipeline results for later use
+- **Cross-pipeline sharing**: Hand values to a later pipeline run, which reads them with `{{ secret }}`

--- a/internal/pkg/pipeline/task/compress/README.md
+++ b/internal/pkg/pipeline/task/compress/README.md
@@ -33,9 +33,6 @@ The task receives records from its input channel, applies compression/decompress
 - **gzip**: Standard gzip compression
 - **snappy**: Fast compression/decompression
 
-An unrecognized `format` fails at config load. `action`, by contrast, is not validated: any
-value other than `compress` decompresses, so a typo silently inverts the task.
-
 ## Example Configurations
 
 ### Compress data with gzip:

--- a/internal/pkg/pipeline/task/compress/README.md
+++ b/internal/pkg/pipeline/task/compress/README.md
@@ -22,17 +22,19 @@ The task receives records from its input channel, applies compression/decompress
 |-------|------|---------|-------------|
 | `name` | string | - | Task name for identification |
 | `type` | string | `compress` | Must be "compress" |
-| `format` | string | - | Compression format (gzip, snappy, etc.) |
-| `action` | string | - | Action type (compress or decompress) |
+| `format` | string | `gzip` | Compression format — `gzip` or `snappy` |
+| `action` | string | `compress` | `compress` or `decompress` |
+| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
+| `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
 
 ## Supported Formats
 
-The task supports various compression formats:
 - **gzip**: Standard gzip compression
 - **snappy**: Fast compression/decompression
-- **zlib**: Standard zlib compression
-- **deflate**: Deflate compression algorithm
+
+An unrecognized `format` fails at config load. `action`, by contrast, is not validated: any
+value other than `compress` decompresses, so a typo silently inverts the task.
 
 ## Example Configurations
 

--- a/internal/pkg/pipeline/task/converter/README.md
+++ b/internal/pkg/pipeline/task/converter/README.md
@@ -23,11 +23,7 @@ The converter task transforms data between different formats. It receives record
 | `name` | string | - | Task name for identification |
 | `type` | string | `converter` | Must be "converter" |
 | `format` | string | - | Format to convert to (csv, html, sst, xlsx, xls, eml, protobuf) |
-| `delimiter` | string | - | SST only: splits key from value. No default — an empty value takes the first character as the key. |
-
-`fail_on_error`, `task_concurrency` and `context` are accepted on a `converter` task but
-silently discarded; only `name`, `type`, `format`, `delimiter` and the per-format options below
-are read.
+| `delimiter` | string | - | SST only: separator between key and value |
 
 ### CSV Format Options
 

--- a/internal/pkg/pipeline/task/converter/README.md
+++ b/internal/pkg/pipeline/task/converter/README.md
@@ -12,7 +12,7 @@ The converter task transforms data between different formats. It receives record
 
 - If skip_first is True and no columns are provided, then the column names in the output will be the values in the first row of the CSV file, normalized: non-alphanumeric characters are replaced by underscores, leading/trailing underscores are trimmed, and the result is lowercased.
 - If skip_first is True and columns are provided, then the column names in the output will be the values provided (i.e., Provided column names supersede names from first row).
-- If skip_first is False, and no columns are provided, then the column names in the output will be named Col1, Col2, Col3, etc.
+- If skip_first is False, and no columns are provided, then the column names in the output will be named col1, col2, col3, etc.
 - If skip_first is False, and columns are provided, then the column names in the output will be the values provided.
 - A leading UTF-8 BOM is stripped from the first record, so it neither breaks parsing nor leaks into a column name or value.
 
@@ -23,7 +23,11 @@ The converter task transforms data between different formats. It receives record
 | `name` | string | - | Task name for identification |
 | `type` | string | `converter` | Must be "converter" |
 | `format` | string | - | Format to convert to (csv, html, sst, xlsx, xls, eml, protobuf) |
-| `delimiter` | string| \t | Used only in sst converter for spliting key and value| 
+| `delimiter` | string | - | SST only: splits key from value. No default — an empty value takes the first character as the key. |
+
+`fail_on_error`, `task_concurrency` and `context` are accepted on a `converter` task but
+silently discarded; only `name`, `type`, `format`, `delimiter` and the per-format options below
+are read.
 
 ### CSV Format Options
 
@@ -140,6 +144,7 @@ tasks:
     type: converter
     format: html
     container: "//div[@class='content']"
+```
 
 ### EML processing:
 ```yaml
@@ -151,7 +156,6 @@ tasks:
     type: converter
     format: eml
   # Output will correspond to body parts and attachments
-```
 ```
 
 ### Excel to CSV conversion (all sheets):
@@ -241,7 +245,8 @@ tasks:
 - `test/pipelines/convert_file.yaml` - File format conversion
 - `test/pipelines/convert_industries.yaml` - Data format transformation
 - `test/pipelines/converter/convert_xls.yaml` - Excel to CSV conversion
-- `test/pipelines/html2json.yaml` - HTML to JSON conversion
+- `test/pipelines/converter/eml.yaml` - MIME/EML email parsing
+- `test/pipelines/converter/protobuf.yaml` - Protobuf decoding
 
 ## Use Cases
 

--- a/internal/pkg/pipeline/task/delay/README.md
+++ b/internal/pkg/pipeline/task/delay/README.md
@@ -16,8 +16,12 @@ The delay task adds a specified delay between processing each record. It receive
 |-------|------|---------|-------------|
 | `name` | string | - | Task name for identification |
 | `type` | string | `delay` | Must be "delay" |
-| `duration` | string | - | Delay duration (e.g., "1s", "100ms", "2m") |
+| `duration` | duration | `100ms` | Delay duration (e.g., "1s", "100ms", "2m") |
+| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
+| `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
+
+Omitting `duration` still sleeps 100ms per record.
 
 ## Duration Format
 
@@ -52,10 +56,6 @@ tasks:
     type: delay
     duration: 5m
 ```
-
-## Sample Pipelines
-
-- `test/pipelines/delay_test.yaml` - Delay task examples
 
 ## Use Cases
 

--- a/internal/pkg/pipeline/task/echo/README.md
+++ b/internal/pkg/pipeline/task/echo/README.md
@@ -17,7 +17,11 @@ The echo task prints data to the console for debugging and monitoring. It receiv
 | `name` | string | - | Task name for identification |
 | `type` | string | `echo` | Must be "echo" |
 | `only_data` | bool | `false` | If true, prints only the data field. If false, prints the full record as JSON |
+| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
+| `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
+
+Each line is printed as `<timestamp> - <task name> - <payload>`. The field is `only_data`; `data_only` is silently ignored.
 
 ## Example Configuration
 

--- a/internal/pkg/pipeline/task/echo/README.md
+++ b/internal/pkg/pipeline/task/echo/README.md
@@ -21,7 +21,7 @@ The echo task prints data to the console for debugging and monitoring. It receiv
 | `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
 
-Each line is printed as `<timestamp> - <task name> - <payload>`. The field is `only_data`; `data_only` is silently ignored.
+Each line is printed as `<timestamp> - <task name> - <payload>`.
 
 ## Example Configuration
 

--- a/internal/pkg/pipeline/task/file/README.md
+++ b/internal/pkg/pipeline/task/file/README.md
@@ -35,10 +35,15 @@ In read mode, two values are stored in each record's context:
 | `region` | string | `us-west-2` | AWS region for S3 operations |
 | `storage_class` | string | `STANDARD` | S3 **write** only: on `PutObject`. Ignored for local paths. See [S3 storage class](#s3-storage-class). |
 | `tags` | map[string]string | - | S3 **write** only: object tags applied on `PutObject`. Ignored for local paths. Values support macros and context templates. See [S3 object tags](#s3-object-tags). |
-| `delimiter` | string | `\n` | Delimiter used to separate records when reading |
 | `success_file` | bool | `false` | Whether to create a success file after writing |
 | `success_file_name` | string | `_SUCCESS` | Name of the success file |
+| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
+| `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
+
+A read emits **one record per file**, holding the whole file — it does not split on lines. Put a
+[`split`](../split) task after it to get a record per line. A `delimiter` field is accepted and has
+no effect.
 
 ## S3 storage class
 
@@ -118,7 +123,6 @@ tasks:
   - name: read_data
     type: file
     path: /path/to/input.txt
-    delimiter: "\n"
 ```
 
 ### Writing to S3:
@@ -161,7 +165,7 @@ tasks:
 
   - name: write_mirrored
     type: file
-    path: s3://dest-bucket/ds={{ macro "date" }}/{{ context "CATERPILLAR_FILE_PATH_WRITE" }}
+    path: s3://dest-bucket/ds={{ macro "timestamp" }}/{{ context "CATERPILLAR_FILE_PATH_WRITE" }}
     region: us-east-1
 ```
 

--- a/internal/pkg/pipeline/task/file/README.md
+++ b/internal/pkg/pipeline/task/file/README.md
@@ -42,8 +42,7 @@ In read mode, two values are stored in each record's context:
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
 
 A read emits **one record per file**, holding the whole file — it does not split on lines. Put a
-[`split`](../split) task after it to get a record per line. A `delimiter` field is accepted and has
-no effect.
+[`split`](../split) task after it to get a record per line.
 
 ## S3 storage class
 

--- a/internal/pkg/pipeline/task/flatten/README.md
+++ b/internal/pkg/pipeline/task/flatten/README.md
@@ -4,7 +4,7 @@ The `flatten` task flattens nested JSON structures into a single level, making c
 
 ## Function
 
-The flatten task takes nested JSON objects and converts them into flat key-value pairs, where nested keys are represented using dot notation or other separators.
+The flatten task takes nested JSON objects and converts them into flat key-value pairs, joining nested keys with an underscore. The separator is not configurable.
 
 ## Behavior
 
@@ -17,6 +17,8 @@ The flatten task converts nested JSON structures into flat key-value pairs. It r
 | `name` | string | - | Task name for identification |
 | `type` | string | `flatten` | Must be "flatten" |
 | `include_original` | string | - | Key name to include the original nested structure |
+| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
+| `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
 
 ## Example Configurations
@@ -35,10 +37,6 @@ tasks:
     type: flatten
     include_original: "original_data"
 ```
-
-## Sample Pipelines
-
-- `test/pipelines/flatten_test.yaml` - Flatten task examples
 
 ## Use Cases
 

--- a/internal/pkg/pipeline/task/heimdall/README.md
+++ b/internal/pkg/pipeline/task/heimdall/README.md
@@ -30,11 +30,14 @@ When used with an input channel, the task acts as a destination. It processes ea
 | `type` | string | `heimdall` | Must be "heimdall" |
 | `endpoint` | string | `http://localhost:9090` | Heimdall API endpoint |
 | `headers` | map[string]string | - | HTTP headers for API requests |
-| `poll_interval` | int | `5` | Polling interval in seconds for async jobs |
-| `timeout` | int | `300` | Job timeout in seconds |
+| `poll_interval` | duration | `5s` | Polling interval for async jobs |
+| `timeout` | duration | `5m` | Job timeout |
 | `get_result` | bool | `true` | Whether to fetch results from the `/result` endpoint after job completion.
-| `job` | object | - | Job configuration (see Job Configuration) |
+| `job` | object | - | Job configuration, **required** (see Job Configuration) |
+| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
+
+`poll_interval` and `timeout` take a string with a unit (`10s`, `1h`); a bare number fails to parse.
 
 ## Job Configuration
 
@@ -47,7 +50,7 @@ The `job` field contains the job specification:
 | `context` | map[string]any | - | Job execution context |
 | `command_criteria` | []string | - | Criteria to match commands |
 | `cluster_criteria` | []string | - | Criteria to match clusters |
-| `tags` | []string | - | Job tags |
+| `tags` | []string | - | Job tags. A `caterpillar_task_name:<task name>` tag is always appended. |
 
 ## Example Configurations
 
@@ -88,8 +91,8 @@ tasks:
   - name: submit_spark_job
     type: heimdall
     endpoint: http://heimdall.example.com
-    timeout: 3600  # 1 hour timeout
-    poll_interval: 10  # Check every 10 seconds
+    timeout: 1h
+    poll_interval: 10s
     job:
       name: spark-analysis
       command_criteria: ["type:spark"]
@@ -127,10 +130,6 @@ tasks:
 ```
 
 In this example, the `jq` task transforms the HTTP response data into a proper job context object with a query field. The heimdall task then uses this context when submitting the job to Heimdall. Each record processed by the pipeline will trigger a separate Heimdall job with the context derived from the jq transformation.
-
-## Sample Pipelines
-
-- `test/pipelines/heimdall.yaml` - Heimdall job submission example
 
 ## Use Cases
 

--- a/internal/pkg/pipeline/task/http/README.md
+++ b/internal/pkg/pipeline/task/http/README.md
@@ -18,7 +18,7 @@ In both modes, the task sends HTTP response data to its output channel and suppo
 
 ### Response Format and Headers
 
-The HTTP task outputs the response body as-is (maintains backward compatibility). Response headers are automatically stored in the record's context with the prefix `http-header-`, making them accessible to downstream tasks via context variables.
+The HTTP task outputs the response body as-is. Response headers are automatically stored in the record's context with the prefix `http-header-`, making them accessible to downstream tasks via context variables.
 
 For example, if the HTTP response includes a `Content-Type` header, it will be available as `{{ context "http-header-Content-Type" }}` in subsequent tasks. Note that HTTP header names are case-sensitive when used as context keys. Go's HTTP library canonicalizes header names (for example, `content-type` becomes `Content-Type`), so you must use the canonical form when accessing headers via context (for example, `http-header-Content-Type`, not `http-header-content-type`).
 
@@ -109,19 +109,24 @@ There is no cap on iterations: an expression that never returns `empty` loops fo
 | `endpoint` | string | - | Target URL for the request |
 | `headers` | map[string]string | - | HTTP headers to include |
 | `body` | string | - | Request body for POST/PUT requests |
-| `timeout` | int | `90` | Request timeout in seconds |
+| `timeout` | duration | `90s` | Request timeout |
 | `max_retries` | int | `3` | Maximum number of retry attempts |
-| `retry_delay` | int | `5` | Delay between retries in seconds |
-| `expected_statuses` | string | `200` | Comma-separated list of expected HTTP status codes |
+| `retry_delay` | duration | `1s` | Delay between retries |
+| `expected_statuses` | string | `200` | Comma-separated list of expected HTTP status codes; ranges are allowed, e.g. `200..299,304` |
 | `oauth` | object | - | OAuth configuration (see OAuth section) |
-| `proxy` | object | - | Proxy configuration |
-| `next_page` | string/object | - | JQ expression to extract next page URL (string) or pagination config (object with `endpoint`, `method`, `body`, `headers`, `context`) — see [Pagination](#pagination) |
+| `proxy` | object | - | Proxy configuration (see Proxy section) |
+| `next_page` | string | - | JQ expression driving pagination; its *result* may be a URL string or an object with `endpoint`, `method`, `body`, `headers`, `context` — see [Pagination](#pagination) |
+| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
 | `context` | map[string]string | - | JQ expressions to extract values from the response and store in record context |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
 
+`timeout` and `retry_delay` take a string with a unit (`90s`, `500ms`, `2m`); a bare number
+fails to parse.
+
 ## OAuth Configuration
 
-The task supports both OAuth 1.0 and OAuth 2.0:
+The task supports both OAuth 1.0 and OAuth 2.0. `version` selects the flow and defaults to
+`1.0`, so the OAuth 2.0 path requires setting it explicitly.
 
 ### OAuth 1.0
 ```yaml
@@ -131,15 +136,42 @@ oauth:
   token: "your_token"
   token_secret: "your_token_secret"
   version: "1.0"
-  signature_method: "HMAC-SHA256"
+  realm: "optional-realm"
 ```
+
+The signature is always HMAC-SHA256. `signature_method` is copied into the Authorization header
+(default `HMAC-SHA256`) and does not select a different algorithm.
 
 ### OAuth 2.0
 ```yaml
 oauth:
+  version: "2.0"
   token_uri: "https://oauth2.googleapis.com/token"
   grant_type: "client_credentials"
   scope: ["https://www.googleapis.com/auth/cloud-platform"]
+  issuer: "service-account@project.iam.gserviceaccount.com"
+  subject: "user@example.com"
+  audience: "https://oauth2.googleapis.com/token"
+  private_key: "{{ secret \"/prod/api/private_key\" }}"
+```
+
+The 2.0 flow builds a signed JWT assertion, so `private_key`, `issuer`, `subject` and
+`audience` are all required for it.
+
+## Proxy Configuration
+
+`scheme` must be `http` or `https`. Under `https` a `ca_certificate` is mandatory and holds the
+**PEM text itself**, not a path to it — literal `\n` sequences in the value are expanded, so a
+one-line secret works.
+
+```yaml
+proxy:
+  scheme: https
+  host: proxy.internal:3128
+  username: "{{ env \"PROXY_USER\" }}"
+  password: "{{ env \"PROXY_PASSWORD\" }}"
+  ca_certificate: "{{ secret \"/prod/proxy/ca_certificate\" }}"
+  insecure_tls: false
 ```
 
 ## Example Configurations
@@ -166,8 +198,8 @@ tasks:
       Content-Type: application/json
     body: '{"name": "test", "value": 123}'
     oauth:
-      consumer_key: "{{ env 'OAUTH_KEY' }}"
-      consumer_secret: "{{ env 'OAUTH_SECRET' }}"
+      consumer_key: "{{ env \"OAUTH_KEY\" }}"
+      consumer_secret: "{{ env \"OAUTH_SECRET\" }}"
 ```
 
 ### Using context variables:
@@ -205,7 +237,7 @@ tasks:
 
 - `test/pipelines/convert_industries.yaml` - HTTP GET request to fetch CSV data
 - `test/pipelines/context_test.yaml` - JQ task forming HTTP request configuration passed to HTTP task
-- `test/pipelines/proxy_test.yaml` - HTTP with proxy configuration
+- `test/pipelines/next_page_context_test.yaml` - Paginated HTTP with `next_page` writing record context
 
 ## Use Cases
 

--- a/internal/pkg/pipeline/task/http/README.md
+++ b/internal/pkg/pipeline/task/http/README.md
@@ -139,9 +139,6 @@ oauth:
   realm: "optional-realm"
 ```
 
-The signature is always HMAC-SHA256. `signature_method` is copied into the Authorization header
-(default `HMAC-SHA256`) and does not select a different algorithm.
-
 ### OAuth 2.0
 ```yaml
 oauth:

--- a/internal/pkg/pipeline/task/http/server/README.md
+++ b/internal/pkg/pipeline/task/http/server/README.md
@@ -8,7 +8,15 @@ The HTTP server task creates a web server that listens for incoming HTTP request
 
 ## Behavior
 
-The HTTP server task starts a web server that listens for incoming HTTP requests. It operates as a data source (no input channel required), accepts HTTP requests on the configured port, and sends each request as a record to its output channel. The record contains the request body as data and request metadata (headers, method, URL) as context. The server can be configured to stop after a specified number of requests.
+The HTTP server task starts a web server that listens for incoming HTTP requests. It operates as a data source (no input channel required), accepts HTTP requests on the configured port, and sends each request as a record to its output channel.
+
+Each record's **data** is a JSON object carrying the request's `method`, `path`, `query`, `body`
+and `headers` — the metadata travels in the payload, not in the record context. Reach a field
+with a downstream `jq` task (e.g. `path: .body`).
+
+The server serves only the method/path pairs listed in `paths`, defaulting to a single
+`GET /`. A request whose method does not match the configured method for that path is
+rejected with `405 Method not allowed`.
 
 ## Configuration Fields
 
@@ -17,20 +25,47 @@ The HTTP server task starts a web server that listens for incoming HTTP requests
 | `name` | string | - | Task name for identification |
 | `type` | string | `http_server` | Must be "http_server" |
 | `port` | int | `8080` | Port number to listen on |
-| `end_after` | int | - | Stop server after specified number of requests |
+| `paths` | list | `GET /` | Method/path pairs to serve; each item takes `method` and `path` |
+| `end_after` | duration | - | Shut the server down after this much time, e.g. `10s` |
+| `read_timeout` | duration | `15s` | Request read timeout |
+| `write_timeout` | duration | `15s` | Response write timeout |
+| `idle_timeout` | duration | `5s` | Keep-alive idle timeout |
 | `auth` | object | - | Authentication configuration (see Auth section) |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
 
+Duration fields take a string with a unit (`10s`, `5m`); a bare number fails to parse.
+Without `end_after` the server runs until the process is stopped.
+`task_concurrency` is accepted but forced to 1 — only one server instance runs.
+
 ## Authentication Configuration
 
-The server supports API key authentication:
+Set `auth.behavior` to one of `api-key`, `basic-auth`, or `ip-whitelist`. Each behavior reads
+its own fields; an unrecognized value fails the task.
 
 ```yaml
+# api-key: every header listed must be present on the request with a matching value
 auth:
   behavior: api-key
   headers:
     Authorization: your-api-key-here
+
+# basic-auth: HTTP Basic credentials
+auth:
+  behavior: basic-auth
+  username: pipeline
+  password: {{ env "SERVER_PASSWORD" }}
+
+# ip-whitelist: only these source addresses are served
+auth:
+  behavior: ip-whitelist
+  whitelist_ips:
+    - 10.0.0.1
+    - 10.0.0.2
 ```
+
+`ip-whitelist` matches the first address in `X-Forwarded-For` when that header is present,
+falling back to the peer address — so it trusts the header, and is only meaningful behind a
+proxy that overwrites it.
 
 ## Example Configurations
 
@@ -54,19 +89,31 @@ tasks:
         Authorization: Bearer {{ env "API_KEY" }}
 ```
 
-### Limited request server:
+### Server that shuts itself down:
 ```yaml
 tasks:
   - name: test_server
     type: http_server
     port: 8080
-    end_after: 100
+    end_after: 30s
+```
+
+### Receiving a POST webhook on a custom path:
+```yaml
+tasks:
+  - name: webhook_receiver
+    type: http_server
+    port: 8080
+    paths:
+      - method: POST
+        path: /events
 ```
 
 ## Sample Pipelines
 
 - `test/pipelines/http_server.yaml` - Basic HTTP server example
 - `test/pipelines/http_server_rest.yaml` - HTTP server with REST API interaction
+- `test/pipelines/basic_auth_test.yaml` - HTTP server with basic authentication
 
 ## Use Cases
 
@@ -87,18 +134,17 @@ tasks:
 - Returns HTTP response to the client
 
 ### Supported HTTP Methods:
-- GET, POST, PUT, DELETE, PATCH
-- Request body is included in the record data
-- Headers are preserved in the record context
+- Any method may be configured, but each `paths` entry serves exactly one; anything else gets `405`
+- Request body, method, path, query and headers are all included in the record data
 
 ### Response Handling:
-- Returns appropriate HTTP status codes
-- Can be configured to return custom responses
-- Handles errors gracefully
+- A served request returns `{"ok":true}`
+- A rejected request returns `401` with `{"ok":false, "error":"access denied"}`
+- An unreadable body returns `400`
 
 ## Security Considerations
 
-- **Authentication**: Use API key authentication for production deployments
+- **Authentication**: Configure `auth` for production deployments
 - **HTTPS**: Consider using HTTPS for secure data transmission
 - **Input validation**: Validate incoming request data
 - **Rate limiting**: Consider implementing rate limiting for high-traffic scenarios

--- a/internal/pkg/pipeline/task/join/README.md
+++ b/internal/pkg/pipeline/task/join/README.md
@@ -8,7 +8,7 @@ The join task collects multiple input records and combines them into a single ou
 
 ## Behavior
 
-The join task combines multiple records into a single record. It receives records from its input channel, buffers them, and sends joined records to its output channel when any of the configured limits are reached (size, number, or duration). The task flushes immediately when the first limit is satisfied, making it useful for flexible batch processing scenarios.
+The join task combines multiple records into a single record. It receives records from its input channel, buffers them, and sends joined records to its output channel when a configured limit is reached (size, number, or duration). With no limits set, it buffers everything and emits one record when the input closes. The buffer is always flushed when the input closes, so no records are lost.
 
 ## Configuration Fields
 
@@ -18,9 +18,16 @@ The join task combines multiple records into a single record. It receives record
 | `type` | string | `join` | Must be "join" |
 | `size` | int | - | Maximum total size (in bytes) before flushing joined records |
 | `number` | int | - | Maximum number of records before flushing joined records |
-| `duration` | string | - | Maximum time duration before flushing joined records |
+| `duration` | duration | - | Time-based flush interval — see the caveat below |
 | `delimiter` | string | `\n` | Delimiter used to separate joined records |
+| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
+| `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
+
+> **`duration` does not bound latency on an idle input.** The task waits for the next record
+> before it re-checks the timer, so a tick is only observed once another record arrives. On a
+> quiet input the buffer sits until the input closes, however long that takes. Use `duration`
+> to cap batch age on a *busy* stream; do not rely on it to flush a trickle promptly.
 
 ## Example Configurations
 

--- a/internal/pkg/pipeline/task/join/README.md
+++ b/internal/pkg/pipeline/task/join/README.md
@@ -18,16 +18,11 @@ The join task combines multiple records into a single record. It receives record
 | `type` | string | `join` | Must be "join" |
 | `size` | int | - | Maximum total size (in bytes) before flushing joined records |
 | `number` | int | - | Maximum number of records before flushing joined records |
-| `duration` | duration | - | Time-based flush interval — see the caveat below |
+| `duration` | duration | - | Maximum time duration before flushing joined records |
 | `delimiter` | string | `\n` | Delimiter used to separate joined records |
 | `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
 | `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
-
-> **`duration` does not bound latency on an idle input.** The task waits for the next record
-> before it re-checks the timer, so a tick is only observed once another record arrives. On a
-> quiet input the buffer sits until the input closes, however long that takes. Use `duration`
-> to cap batch age on a *busy* stream; do not rely on it to flush a trickle promptly.
 
 ## Example Configurations
 

--- a/internal/pkg/pipeline/task/jq/README.md
+++ b/internal/pkg/pipeline/task/jq/README.md
@@ -83,7 +83,7 @@ tasks:
     type: jq
     path: |
       {
-        "endpoint": "https://api.example.com/users/{{ context 'user_id' }}"
+        "endpoint": "https://api.example.com/users/{{ context \"user_id\" }}"
       }
 ```
 
@@ -126,7 +126,24 @@ tasks:
 
 ## Custom JQ Functions
 
-In addition to standard JQ functions, Caterpillar provides custom functions to extend JQ capabilities:
+In addition to standard JQ functions, Caterpillar provides custom functions to extend JQ
+capabilities. `bcrypt` and `translate` are described in detail below; the rest are:
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `md5` | `<string> \| md5` | Hex-encoded MD5 of the piped string |
+| `sha256` | `<string> \| sha256` | Hex-encoded SHA-256 of the piped string |
+| `sha512` | `<string> \| sha512` | Hex-encoded SHA-512 of the piped string |
+| `hmac_md5` | `hmac_md5(data; key)` or `hmac_md5(data; key; prefix)` | Hex-encoded HMAC-MD5 of `data` under `key`; the optional `prefix` bytes are placed ahead of the digest before hex-encoding |
+| `hmac_sha256` | `hmac_sha256(data; key)` or `hmac_sha256(data; key; prefix)` | Hex-encoded HMAC-SHA-256, same argument shape |
+| `hmac_sha512` | `hmac_sha512(data; key)` or `hmac_sha512(data; key; prefix)` | Hex-encoded HMAC-SHA-512, same argument shape |
+| `rsa_sha256` | `rsa_sha256(hex_digest; private_key)` | Base64 RSA PKCS#1 v1.5 signature. `hex_digest` is an already-hashed, hex-encoded SHA-256 digest, not the raw message; `private_key` is PEM text |
+| `rsa_sha512` | `rsa_sha512(hex_digest; private_key)` | As above, over SHA-512 |
+| `uuid` | `uuid` | A new random UUID; ignores its input |
+| `shuffle` | `<array> \| shuffle` | The piped array in random order |
+| `sleep` | `sleep("1s")` | Pauses for a duration string, then passes the input through unchanged |
+
+`test/pipelines/hash_test.yaml` and `test/pipelines/uuid_test.yaml` exercise these.
 
 ### bcrypt
 

--- a/internal/pkg/pipeline/task/kafka/README.md
+++ b/internal/pkg/pipeline/task/kafka/README.md
@@ -17,7 +17,7 @@ There are two read modes, controlled by whether `group_id` is set:
 - **Standalone** (no `group_id`): assigns all partitions directly at `OffsetBeginning` and reads without committing offsets. Every run re-reads from the start of the topic. Useful for one-shot batch reads or testing.
 - **Group consumer** (`group_id` set): subscribes via the Kafka consumer group protocol, reads from committed offsets, and commits new offsets periodically. Multiple instances with the same `group_id` split partitions and each message is delivered once to the group. The `auto_offset_reset` field controls behavior when no committed offset is found or the stored offset is out of range (e.g., aged out by retention) — `latest` (default) skips to the tail, `earliest` starts from the beginning of the available log.
 
-> **Broker ACL requirement for standalone mode**: confluent-kafka-go requires a non-empty `group.id` even for direct-assign reads. Standalone mode uses the group ID `caterpillar-standalone-<topic>`. The Kafka principal used by this task must have `READ` permission on `GROUP` resource `caterpillar-standalone-` with `PREFIXED` pattern type. Without this ACL, standalone reads will fail with a group authorization error.
+> **Broker ACL requirement for standalone mode**: confluent-kafka-go requires a non-empty `group.id` even for direct-assign reads. Standalone mode builds one per run as `caterpillar-standalone-<topic>-<uuid>`. Grant `READ` on `GROUP` resource `caterpillar-standalone-` with `PREFIXED` pattern type. Without this ACL, standalone reads fail with a group authorization error.
 
 ## Configuration Fields
 
@@ -29,6 +29,9 @@ There are two read modes, controlled by whether `group_id` is set:
 | `topic` | string | - | Topic to read from or write to (required) |
 | `timeout` | duration string | `15s` | Read polling timeout and producer delivery/flush timeout. Uses Go duration format (e.g. `25s`, `1m`). |
 | `batch_flush_interval` | duration string | `2s` | Producer linger interval (`linger.ms`) for batching queued writes |
+| `batch_size` | int | `100` | Producer batch size (`batch.num.messages`) — messages per batch, alongside the `batch_flush_interval` time trigger |
+| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
+| `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
 | `retry_limit` | int | `5` | Read retry threshold; reading stops when consecutive retryable errors or timeouts exceed this value |
 | `end_after` | duration string | - | Wall-clock deadline for read mode. When set, the reader stops cleanly after this duration regardless of message traffic. Worst-case overshoot is one `timeout` window. |
 | `max_records` | int | `0` (unlimited) | Read-mode cap on records forwarded downstream. The reader stops cleanly once this many messages have been sent. In group mode, offsets up to the last forwarded record are committed on shutdown. Must be `>= 0`; negative values are rejected at validation. |
@@ -38,11 +41,11 @@ There are two read modes, controlled by whether `group_id` is set:
 | `server_auth_type` | string | `none` | `none` or `tls` — server certificate verification mode |
 | `cert` | string | - | CA certificate PEM/CRT content used when `server_auth_type: tls` (alternatively use `cert_path`) |
 | `cert_path` | string | - | Path to CA certificate (PEM/CRT) |
-| `user_auth_type` | string | `none` | `none`, `sasl`, `scram`, or `mtls` — `mtls` is currently not implemented and returns an error |
+| `user_auth_type` | string | `none` | `none`, `sasl`, `scram`, or `mtls` — `mtls` is not implemented and returns an error |
 | `username` | string | - | Username for SASL/SCRAM authentication |
 | `password` | string | - | Password for SASL/SCRAM authentication |
 | `idempotent` | bool | `false` | Enables the idempotent producer (`enable.idempotence=true`, `max.in.flight.requests.per.connection=5`) |
-| `format` | string | `json` | Message serialization format. `json` passes raw bytes through unchanged (default, backward compatible). `avro` serializes JSON→Avro on write and Avro→JSON on read using Confluent Schema Registry. |
+| `format` | string | `json` | Message serialization format. `json` passes raw bytes through unchanged. `avro` serializes JSON→Avro on write and Avro→JSON on read using Confluent Schema Registry. |
 | `schema_registry_url` | string | - | Schema Registry URL. Required when `format: avro`. Schemas must be pre-registered; auto-registration is disabled. |
 | `schema_registry_username` | string | - | Schema Registry basic auth username |
 | `schema_registry_password` | string | - | Schema Registry basic auth password |
@@ -52,7 +55,7 @@ There are two read modes, controlled by whether `group_id` is set:
 - `server_auth_type: tls` enables server certificate verification using the CA at `cert` or, if absent, the CA file at `cert_path`.
 - `user_auth_type: sasl` uses SASL Plain authentication (requires `username` and `password`).
 - `user_auth_type: scram` uses SCRAM-SHA-512 authentication (requires `username` and `password`).
-- `user_auth_type: mtls` is reserved for mTLS (client cert) but is not implemented in this task yet and will return an error if configured.
+- `user_auth_type: mtls` is reserved for mTLS (client cert) but is not implemented and returns an error if configured.
 
 If you choose SASL/SCRAM and `server_auth_type: tls`, the task configures Confluent's `security.protocol` as `SASL_SSL`. Without TLS, SASL uses `SASL_PLAINTEXT`.
 
@@ -215,7 +218,7 @@ tasks:
 ```
 
 ## Notes and Limitations
- - **Standalone mode** reads all partitions from `OffsetBeginning` on every run and never commits offsets. It requires a broker PREFIXED ACL on group `caterpillar-standalone-` (see Reading Modes above).
+ - **Standalone mode** reads all partitions from `OffsetBeginning` on every run and never commits offsets. The PREFIXED group ACL is covered under Reading Modes above.
  - **Group consumer mode** resumes from committed offsets. `auto_offset_reset` fires only if the group has no prior committed offsets or the stored offset is out of range (e.g., aged out by retention). To re-read from the beginning, reset group offsets via `kafka-consumer-groups.sh --reset-offsets --to-earliest`.
  - **Out-of-range stored offset:** librdkafka logs a `%4|OFFSET ... offset reset` warning when this happens. It's informational — the consumer self-recovers to the position implied by `auto_offset_reset`. The warning persists across restarts until a successful read commits a new valid offset (or until you manually reset the group offsets at the broker).
  - **`end_after`** sets a wall-clock read deadline distinct from `retry_limit` (which is idle-based). Use `end_after` when you want a guaranteed stop time even on a busy topic. Worst-case shutdown latency is one `timeout` window because in-flight `ReadMessage` polls cannot be canceled mid-flight.

--- a/internal/pkg/pipeline/task/replace/README.md
+++ b/internal/pkg/pipeline/task/replace/README.md
@@ -18,7 +18,11 @@ The replace task performs text replacement using regular expressions. It receive
 | `type` | string | `replace` | Must be "replace" |
 | `expression` | string | - | Regular expression pattern to match |
 | `replacement` | string | - | Replacement string (supports capture group references) |
+| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
+| `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
+
+This task cannot be last in a pipeline — with no output channel it silently drops every record.
 
 ## Regex Features
 
@@ -79,7 +83,6 @@ tasks:
 ## Sample Pipelines
 
 - `test/pipelines/hello_name.yaml` - Replace task with greeting format
-- `test/pipelines/convert_file.yaml` - Data format conversion
 
 ## Use Cases
 

--- a/internal/pkg/pipeline/task/replace/README.md
+++ b/internal/pkg/pipeline/task/replace/README.md
@@ -22,8 +22,6 @@ The replace task performs text replacement using regular expressions. It receive
 | `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
 
-This task cannot be last in a pipeline — with no output channel it silently drops every record.
-
 ## Regex Features
 
 The replace task supports standard regex features including:

--- a/internal/pkg/pipeline/task/sample/README.md
+++ b/internal/pkg/pipeline/task/sample/README.md
@@ -17,24 +17,29 @@ The sample task filters records using various sampling strategies. It receives r
 | `name` | string | - | Task name for identification |
 | `type` | string | `sample` | Must be "sample" |
 | `filter` | string | `random` | Sampling strategy (random, head, tail, nth, percent) |
-| `limit` | int | `10` | Number of records to keep (for head, tail, nth strategies) |
-| `percent` | int | `1` | Percentage of records to keep (for percent strategy) |
-| `divider` | int | `1000` | Divisor for percentage calculation |
-| `size` | int | `50000` | Buffer size for random sampling |
+| `limit` | int | `10` | Number of records to keep (head, tail, random strategies) |
+| `percent` | int | `1` | Percentage of records to keep, 0-100 (percent strategy) |
+| `divider` | int | `1000` | Keep every Nth record (nth strategy) |
+| `size` | int | `50000` | Buffer size to draw from (random strategy) |
+| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
+| `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
+
+Each strategy reads only its own fields; setting a field another strategy uses has no effect.
 
 ## Sampling Strategies
 
 ### Random Sampling (`random`)
-Randomly selects records based on a percentage. Uses the `percent` and `divider` fields.
+Buffers up to `size` records, then emits `limit` of them drawn at random. Draws are
+independent, so the same record can be emitted more than once.
 
 ```yaml
 tasks:
   - name: random_sample
     type: sample
     filter: random
-    percent: 10  # 10% of records
-    divider: 100
+    limit: 10   # emit 10 records
+    size: 50000 # drawn from the first 50k records seen
 ```
 
 ### Head Sampling (`head`)
@@ -60,14 +65,14 @@ tasks:
 ```
 
 ### Nth Sampling (`nth`)
-Keeps every Nth record from the input.
+Keeps every Nth record from the input, starting with the first.
 
 ```yaml
 tasks:
   - name: every_tenth
     type: sample
     filter: nth
-    limit: 10  # Every 10th record
+    divider: 10  # Every 10th record
 ```
 
 ### Percent Sampling (`percent`)
@@ -83,14 +88,14 @@ tasks:
 
 ## Example Configurations
 
-### Random 5% sampling:
+### Random 5% of a 2000-record buffer:
 ```yaml
 tasks:
   - name: random_sample
     type: sample
     filter: random
-    percent: 5
-    divider: 100
+    limit: 100
+    size: 2000
 ```
 
 ### First 100 records:
@@ -108,7 +113,7 @@ tasks:
   - name: sparse_sample
     type: sample
     filter: nth
-    limit: 50
+    divider: 50
 ```
 
 ## Sample Pipelines

--- a/internal/pkg/pipeline/task/sns/README.md
+++ b/internal/pkg/pipeline/task/sns/README.md
@@ -23,7 +23,10 @@ The SNS task acts as a sink, receiving records from the input channel and publis
 | `subject` | string | - | Optional subject line for the published message |
 | `attributes` | list | - | Optional list of message attributes (name, type, value) |
 | `message_group_id` | string | - | Required for FIFO topics. If not provided for a FIFO topic, a UUID is generated. |
-| `message_deduplication_id` | string | - | Optional for FIFO topics. |
+| `message_deduplication_id` | string | - | Optional for FIFO topics. If not provided, a UUID is generated per message — which makes every message unique and so disables SNS deduplication. Set it to a stable value derived from the payload if you want dedup. |
+| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
+| `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
+| `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
 
 
 ## Example Configurations
@@ -70,3 +73,7 @@ tasks:
     topic_arn: "arn:aws:sns:us-west-2:123456789012:my-topic.fifo"
     message_group_id: "group1"
 ```
+
+## Sample Pipelines
+
+- `test/pipelines/sns_test.yaml` - Publishing records to an SNS topic

--- a/internal/pkg/pipeline/task/split/README.md
+++ b/internal/pkg/pipeline/task/split/README.md
@@ -17,7 +17,11 @@ The split task divides data into multiple records based on a delimiter. It recei
 | `name` | string | - | Task name for identification |
 | `type` | string | `split` | Must be "split" |
 | `delimiter` | string | `\n` | Character or string used to split the data |
+| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
+| `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
+
+One trailing delimiter is trimmed before splitting, so a file ending in a newline does not yield an empty final record.
 
 ## Example Configurations
 

--- a/internal/pkg/pipeline/task/sqs/README.md
+++ b/internal/pkg/pipeline/task/sqs/README.md
@@ -20,10 +20,16 @@ The task automatically determines its mode based on the presence of input/output
 | `queue_url` | string | - | SQS queue URL (required) |
 | `concurrency` | int | `10` | Number of concurrent message processors |
 | `max_messages` | int | `10` | Maximum number of messages to receive per batch |
-| `wait_time` | int | `10` | Long polling wait time in seconds |
+| `wait_time_seconds` | int | `10` | Long polling wait time in seconds |
 | `exit_on_empty` | bool | `false` | Exit when queue is empty |
+| `end_after` | duration | - | Stop polling after this much time (read mode); e.g. `5m` |
 | `message_group_id` | string | - | Message group ID for FIFO queues |
+| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
+| `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
+
+In read mode the task polls until the queue drains (`exit_on_empty`) or `end_after` elapses;
+with neither set it polls indefinitely.
 
 ## Example Configurations
 
@@ -34,7 +40,7 @@ tasks:
     type: sqs
     queue_url: https://sqs.us-west-2.amazonaws.com/123456789012/my-queue
     max_messages: 10
-    wait_time: 10
+    wait_time_seconds: 10
     concurrency: 5
 ```
 
@@ -66,7 +72,7 @@ tasks:
 
 ## Sample Pipelines
 
-- `test/pipelines/sqs_reader.yaml` - SQS message reading example
+- `test/pipelines/sqs_with_context_concurrency.yaml` - SQS read with context variables and concurrency
 
 ## Use Cases
 

--- a/internal/pkg/pipeline/task/xpath/README.md
+++ b/internal/pkg/pipeline/task/xpath/README.md
@@ -33,6 +33,8 @@ The `ignore_missing` configuration controls how the task handles missing element
 | `container` | string | - | XPath expression to select container elements |
 | `fields` | map[string]string | - | Map of field names to XPath expressions |
 | `ignore_missing` | bool | `true` | Whether to ignore missing fields |
+| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
+| `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
 
 ## Context Variables
@@ -101,7 +103,8 @@ tasks:
 
 - `test/pipelines/xpath.yaml` - XPath extraction examples
 - `test/pipelines/xpath_with_index.yaml` - Xpath extraction with node index example
-- `test/pipelines/html2json.yaml` - HTML to JSON conversion
+
+Both read the `test/pipelines/sample.html` fixture.
 
 ## Use Cases
 


### PR DESCRIPTION
## Summary
- Audited every task README against current `main` source so copied YAML matches real field names, types, and defaults (duration strings, `wait_time_seconds`, sample strategy fields, compress formats, http_server `paths`/`end_after`, and similar).
- Kept Parameter Store's write **and** lookup modes from #92, distinguished them from the startup-time `{{ secret }}` template, and fixed the `cache_ttl` description (`0` is treated as unset, not a disable).
- Dropped dead example links, unclosed fences, and invalid template syntax; documented gotchas that a careful reader cannot recover from the field table (archive pack requires `CATERPILLAR_FILE_NAME_WRITE`, join `duration` does not flush an idle input, converter discards `fail_on_error`/`context`).

## Test plan
- [ ] Spot-check each changed README against the task's Go struct (`yaml:` tags, `New()` defaults, `UnmarshalYAML`)
- [ ] Confirm `aws_parameter_store` still documents both `set` and `lookup`, mutually exclusive, with `{{ secret }}` as the startup-time alternative
- [ ] Copy the corrected YAML snippets (http OAuth quotes, http_server `paths`, sample `nth`/`random`, file without `delimiter`) into a local pipeline and load them with `./caterpillar -conf …`
- [ ] Confirm cited `test/pipelines/…` paths exist