### PR TITLE
Assume data-platform SSM role for /caterpillar/ secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.18 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.36 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.36
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.37 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.37 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.37 // indirect
@@ -108,7 +108,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.38 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.6 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.45.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.45.6
 	github.com/aws/smithy-go v1.27.8 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang/snappy v1.0.0

--- a/internal/pkg/config/secret.go
+++ b/internal/pkg/config/secret.go
@@ -3,25 +3,40 @@ package config
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
+
+const dataPlatformCaterpillarSSMRole = `arn:aws:iam::842676014003:role/heimdall-caterpillar-ssm-read`
 
 var (
 	awsTrue = aws.Bool(true)
 	ctx     = context.Background()
 )
 
-func getSecret(path string) (string, error) {
-	var value *ssm.GetParameterOutput
-	var err error
+func assumeRoleARN(path string) string {
+	if strings.HasPrefix(path, `/caterpillar/`) {
+		return dataPlatformCaterpillarSSMRole
+	}
+	return ``
+}
 
+func getSecret(path string) (string, error) {
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return ``, err
+	}
+
+	if roleARN := assumeRoleARN(path); roleARN != `` {
+		cfg.Credentials = aws.NewCredentialsCache(
+			stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), roleARN),
+		)
 	}
 
 	svc := ssm.NewFromConfig(cfg, func(o *ssm.Options) {
@@ -34,11 +49,10 @@ func getSecret(path string) (string, error) {
 		})
 	})
 
-	value, err = svc.GetParameter(ctx, &ssm.GetParameterInput{
+	value, err := svc.GetParameter(ctx, &ssm.GetParameterInput{
 		Name:           aws.String(path),
 		WithDecryption: awsTrue,
 	})
-
 	if err != nil {
 		return ``, err
 	}
@@ -48,5 +62,4 @@ func getSecret(path string) (string, error) {
 	}
 
 	return *value.Parameter.Value, nil
-
 }

--- a/internal/pkg/config/secret.go
+++ b/internal/pkg/config/secret.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -13,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
-const dataPlatformCaterpillarSSMRole = `arn:aws:iam::842676014003:role/heimdall-caterpillar-ssm-read`
+const ssmAssumeRoleEnv = `CATERPILLAR_SSM_ASSUME_ROLE_ARN`
 
 var (
 	awsTrue = aws.Bool(true)
@@ -21,10 +22,10 @@ var (
 )
 
 func assumeRoleARN(path string) string {
-	if strings.HasPrefix(path, `/caterpillar/`) {
-		return dataPlatformCaterpillarSSMRole
+	if !strings.HasPrefix(path, `/caterpillar/`) {
+		return ``
 	}
-	return ``
+	return os.Getenv(ssmAssumeRoleEnv)
 }
 
 func getSecret(path string) (string, error) {

--- a/internal/pkg/config/secret_test.go
+++ b/internal/pkg/config/secret_test.go
@@ -1,12 +1,21 @@
 package config
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestAssumeRoleARN(t *testing.T) {
-	if got := assumeRoleARN(`/caterpillar/github/app_jwt`); got != dataPlatformCaterpillarSSMRole {
-		t.Fatalf("caterpillar path: got %q", got)
+	t.Setenv(ssmAssumeRoleEnv, `arn:aws:iam::842676014003:role/heimdall-caterpillar-ssm-read`)
+
+	if got := assumeRoleARN(`/caterpillar/github/app_jwt`); got != `arn:aws:iam::842676014003:role/heimdall-caterpillar-ssm-read` {
+		t.Fatalf("caterpillar path with env: got %q", got)
 	}
 	if got := assumeRoleARN(`/heimdall/github_svc_account_token`); got != `` {
 		t.Fatalf("heimdall path should not assume: got %q", got)
+	}
+
+	t.Setenv(ssmAssumeRoleEnv, ``)
+	if got := assumeRoleARN(`/caterpillar/github/app_jwt`); got != `` {
+		t.Fatalf("unset env should use task role: got %q", got)
 	}
 }

--- a/internal/pkg/config/secret_test.go
+++ b/internal/pkg/config/secret_test.go
@@ -1,0 +1,12 @@
+package config
+
+import "testing"
+
+func TestAssumeRoleARN(t *testing.T) {
+	if got := assumeRoleARN(`/caterpillar/github/app_jwt`); got != dataPlatformCaterpillarSSMRole {
+		t.Fatalf("caterpillar path: got %q", got)
+	}
+	if got := assumeRoleARN(`/heimdall/github_svc_account_token`); got != `` {
+		t.Fatalf("heimdall path should not assume: got %q", got)
+	}
+}


### PR DESCRIPTION
### Description

`heimdall-task-role` can assume `heimdall-caterpillar-ssm-read`, but ECS does not do that automatically. The Fargate task still runs as `heimdall-task-role` in 122610511428; a cross-account role cannot be set as `taskRoleArn`.

Caterpillar no longer hardcodes a role ARN. If the ECS task sets `CATERPILLAR_SSM_ASSUME_ROLE_ARN`, `{{ secret }}` assumes it for `/caterpillar/` paths, then `GetParameter`. Other secrets keep using the task role.

Companion task-def env: https://github.com/patterninc/heimdall-config/pull/463

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.

## Test plan
- [ ] `go test ./internal/pkg/config/`
- [ ] Deploy this Caterpillar tag **and** the heimdall-config task-def env, then rerun `github_org_members_daily`