### PR TITLE
fix(archive): reject unsupported formats

### DIFF
--- a/internal/pkg/pipeline/task/archive/archive.go
+++ b/internal/pkg/pipeline/task/archive/archive.go
@@ -77,6 +77,9 @@ func (c *core) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if obj.Action != actionPack && obj.Action != actionUnpack {
 		return fmt.Errorf("invalid action: %s (must be 'pack' or 'unpack')", obj.Action)
 	}
+	if _, ok := supportedFormats[obj.Format]; !ok {
+		return fmt.Errorf("invalid format: %s (must be 'zip' or 'tar')", obj.Format)
+	}
 
 	*c = core(obj)
 

--- a/internal/pkg/pipeline/task/archive/archive_test.go
+++ b/internal/pkg/pipeline/task/archive/archive_test.go
@@ -1,0 +1,21 @@
+package archive
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestUnmarshalYAMLRejectsUnsupportedFormat(t *testing.T) {
+	var archive core
+
+	err := yaml.Unmarshal([]byte("format: rar\n"), &archive)
+	if err == nil {
+		t.Fatal("expected unsupported archive format to be rejected")
+	}
+
+	const want = "invalid format: rar (must be 'zip' or 'tar')"
+	if err.Error() != want {
+		t.Fatalf("unexpected error: got %q, want %q", err, want)
+	}
+}


### PR DESCRIPTION
### Description

Fixes #97.

Validates `format` during YAML loading so unsupported values return a configuration error instead of calling a nil archive constructor. Adds a regression test for `format: rar`.

#### Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

#### Test plan

- [x] `go test ./internal/pkg/pipeline/task/archive -count=1`
- [ ] `go test ./... -count=1` — the archive package passes, but the full command cannot compile the existing `confluent-kafka-go` dependency on Windows with `CGO_ENABLED=0` (`undefined: kafka.LibraryVersion`). Linux CI covers the remaining build.