### PR TITLE
fix(sqs): do not treat FIFO empty receives as drained under deferred ack

### DIFF
--- a/internal/pkg/pipeline/task/join/README.md
+++ b/internal/pkg/pipeline/task/join/README.md
@@ -14,7 +14,7 @@ The join task combines multiple records into a single record. It receives record
 
 Caterpillar deletes an SQS message only after every downstream task has finished with the record produced from it. A `join` task with no `size:`, `number:`, or `duration:` limit holds its buffered records until the input channel closes, so the source message stays in flight for the whole run.
 
-On a FIFO queue, an in-flight message blocks its entire message group: SQS does not deliver later messages in that group until the earlier one is deleted. An unbounded `join` on a FIFO-sourced pipeline therefore blocks the group for the run, and throughput collapses to roughly `max_messages` messages per group per run. The SQS reader does not treat those empty receives as a drained queue while it still holds receipts, so `exit_on_empty` keeps polling instead of reporting success with messages left behind. Without a join flush limit the acks never settle and the run does not finish.
+On a FIFO queue, an in-flight message blocks its entire message group: SQS does not deliver later messages in that group until the earlier one is deleted. An unbounded `join` on a FIFO-sourced pipeline therefore blocks the group for the run, and throughput collapses to roughly `max_messages` messages per group per run. Empty FIFO receives while receipts are held are not treated as a drained queue, so `exit_on_empty` keeps polling. Without a join flush limit the acks never settle and the run does not finish.
 
 The queue visibility timeout is not the fix. The gate is an in-flight message, not an expired timeout. Raising the timeout keeps the message in flight longer; lowering it causes SQS to redeliver the same blocked message instead of advancing to the next one in the group.
 

--- a/internal/pkg/pipeline/task/join/README.md
+++ b/internal/pkg/pipeline/task/join/README.md
@@ -14,7 +14,7 @@ The join task combines multiple records into a single record. It receives record
 
 Caterpillar deletes an SQS message only after every downstream task has finished with the record produced from it. A `join` task with no `size:`, `number:`, or `duration:` limit holds its buffered records until the input channel closes, so the source message stays in flight for the whole run.
 
-On a FIFO queue, an in-flight message blocks its entire message group: SQS does not deliver later messages in that group until the earlier one is deleted. An unbounded `join` on a FIFO-sourced pipeline therefore blocks the group for the run, and throughput collapses to roughly `max_messages` messages per group per run. The failure is silent: `ReceiveMessage` returns nothing, `exit_on_empty` fires, and the run reports success while the queue still holds undelivered messages.
+On a FIFO queue, an in-flight message blocks its entire message group: SQS does not deliver later messages in that group until the earlier one is deleted. An unbounded `join` on a FIFO-sourced pipeline therefore blocks the group for the run, and throughput collapses to roughly `max_messages` messages per group per run. The SQS reader does not treat those empty receives as a drained queue while it still holds receipts, so `exit_on_empty` keeps polling instead of reporting success with messages left behind. Without a join flush limit the acks never settle and the run does not finish.
 
 The queue visibility timeout is not the fix. The gate is an in-flight message, not an expired timeout. Raising the timeout keeps the message in flight longer; lowering it causes SQS to redeliver the same blocked message instead of advancing to the next one in the group.
 

--- a/internal/pkg/pipeline/task/sqs/README.md
+++ b/internal/pkg/pipeline/task/sqs/README.md
@@ -21,7 +21,7 @@ The task automatically determines its mode based on the presence of input/output
 | `concurrency` | int | `10` | Number of concurrent workers that acknowledge (delete) fully-processed messages |
 | `max_messages` | int | `10` | Maximum number of messages to receive per batch |
 | `wait_time_seconds` | int | `10` | Long polling wait time in seconds |
-| `exit_on_empty` | bool | `false` | Exit when queue is empty |
+| `exit_on_empty` | bool | `false` | Exit when a receive returns no messages. On FIFO queues this waits until outstanding receipts are deleted, because an empty poll can mean the message group is blocked rather than the queue drained. |
 | `end_after` | duration | - | Stop polling after this much time (read mode); e.g. `5m` |
 | `message_group_id` | string | - | Message group ID for FIFO queues |
 | `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
@@ -98,9 +98,15 @@ Two consequences worth tuning for:
 - **SQS caps in-flight messages** at 120,000 per standard queue and 20,000 per FIFO queue.
   A large `channel_size` on a long pipeline can approach that; on a breach `ReceiveMessage`
   returns `OverLimit` and the task stops. FIFO queues are stricter still, since
-  unacknowledged messages block their message group. An unbounded `join` downstream of
-  read mode is a common cause: set `duration:` on that join so records flush mid-run and
-  messages can be deleted (see the join task README).
+  unacknowledged messages block their message group: later messages in that group are not
+  returned until the in-flight receipts are deleted, so a receive can come back empty while
+  the queue still holds work. `exit_on_empty` therefore does not treat an empty FIFO poll as
+  drained while this task still holds receipts; after those deletes, the next poll either
+  returns the next batch or a true empty. One message group is still capped at
+  `max_messages` in flight by AWS. An unbounded `join` downstream of read mode keeps those
+  receipts outstanding for the run, so the reader keeps polling rather than exiting: set
+  `duration:` (or `size:` / `number:`) on that join so records flush mid-run and messages
+  can be deleted (see the join task README).
 
 ## Sample Pipelines
 

--- a/internal/pkg/pipeline/task/sqs/README.md
+++ b/internal/pkg/pipeline/task/sqs/README.md
@@ -21,7 +21,7 @@ The task automatically determines its mode based on the presence of input/output
 | `concurrency` | int | `10` | Number of concurrent workers that acknowledge (delete) fully-processed messages |
 | `max_messages` | int | `10` | Maximum number of messages to receive per batch |
 | `wait_time_seconds` | int | `10` | Long polling wait time in seconds |
-| `exit_on_empty` | bool | `false` | Exit when a receive returns no messages. On FIFO queues this waits until outstanding receipts are deleted, because an empty poll can mean the message group is blocked rather than the queue drained. |
+| `exit_on_empty` | bool | `false` | Exit when a receive returns no messages. FIFO: empty poll is not drain while receipts are outstanding. |
 | `end_after` | duration | - | Stop polling after this much time (read mode); e.g. `5m` |
 | `message_group_id` | string | - | Message group ID for FIFO queues |
 | `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |

--- a/internal/pkg/pipeline/task/sqs/sqs.go
+++ b/internal/pkg/pipeline/task/sqs/sqs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -39,8 +40,9 @@ type sqs struct {
 	ExitOnEmpty     bool   `yaml:"exit_on_empty,omitempty" json:"exit_on_empty,omitempty"`
 	MessageGroupId  string `yaml:"message_group_id,omitempty" json:"message_group_id,omitempty"` // used for FIFO queues
 
-	client  *qs.Client
-	tracker *ack.Tracker
+	client      *qs.Client
+	tracker     *ack.Tracker
+	outstanding atomic.Int32 // receipts received and not yet Ack'd; FIFO empty polls are not drain while > 0
 }
 
 func New() (task.Task, error) {
@@ -151,7 +153,7 @@ func (s *sqs) getMessages(ctx context.Context, output chan<- *record.Record) err
 			}
 
 			if receiveMessageOutput == nil || len(receiveMessageOutput.Messages) == 0 {
-				if s.ExitOnEmpty {
+				if s.shouldExitOnEmpty() {
 					fmt.Println(`Queue is empty, exiting`)
 					return nil
 				}
@@ -170,6 +172,7 @@ func (s *sqs) getMessages(ctx context.Context, output chan<- *record.Record) err
 				msgAck := ack.New()
 				s.SendData(ack.WithContext(ctx, msgAck), []byte(*m.Body), output)
 
+				s.outstanding.Add(1)
 				s.tracker.Track(msgAck, &messageAck{
 					sqs:           s,
 					messageId:     m.MessageId,
@@ -193,12 +196,31 @@ type messageAck struct {
 // redeliver the message once the visibility timeout expires.
 func (m *messageAck) Ack(failed bool) {
 
+	defer m.sqs.outstanding.Add(-1)
+
 	if failed {
 		return
 	}
 
 	m.sqs.deleteMessage(m.messageId, m.receiptHandle)
 
+}
+
+// shouldExitOnEmpty reports a drained queue. FIFO withholds later messages in a
+// group until in-flight receipts are deleted, so an empty receive is not drain
+// while we still hold any.
+func (s *sqs) shouldExitOnEmpty() bool {
+	if !s.ExitOnEmpty {
+		return false
+	}
+	if s.isFifo() && s.outstanding.Load() > 0 {
+		return false
+	}
+	return true
+}
+
+func (s *sqs) isFifo() bool {
+	return strings.HasSuffix(s.QueueURL, ".fifo")
 }
 
 // deleteMessage acknowledges a message by deleting its receipt. A failure is
@@ -240,8 +262,7 @@ func (s *sqs) sendMessages(input <-chan *record.Record) error {
 }
 
 func (s *sqs) getMessageGroupID() *string {
-	// Only return a group ID if the queue is FIFO (URL ends with .fifo)
-	if strings.HasSuffix(s.QueueURL, ".fifo") {
+	if s.isFifo() {
 
 		if s.MessageGroupId != "" {
 			return &s.MessageGroupId

--- a/internal/pkg/pipeline/task/sqs/sqs.go
+++ b/internal/pkg/pipeline/task/sqs/sqs.go
@@ -42,7 +42,7 @@ type sqs struct {
 
 	client      *qs.Client
 	tracker     *ack.Tracker
-	outstanding atomic.Int32 // receipts received and not yet Ack'd; FIFO empty polls are not drain while > 0
+	outstanding atomic.Int32
 }
 
 func New() (task.Task, error) {
@@ -206,9 +206,8 @@ func (m *messageAck) Ack(failed bool) {
 
 }
 
-// shouldExitOnEmpty reports a drained queue. FIFO withholds later messages in a
-// group until in-flight receipts are deleted, so an empty receive is not drain
-// while we still hold any.
+// FIFO withholds a group until deletes land, so an empty receive is not
+// drained while we still hold receipts.
 func (s *sqs) shouldExitOnEmpty() bool {
 	if !s.ExitOnEmpty {
 		return false


### PR DESCRIPTION
## Summary
- Deferred ack leaves SQS FIFO message groups blocked until receipts are deleted, so the next `ReceiveMessage` can return nothing while the queue still holds work.
- `exit_on_empty` now skips that empty poll on `.fifo` queues while this task still holds outstanding receipts; after deletes, the next poll either returns the next batch or a true empty.
- Unbounded `join` on a FIFO source keeps polling instead of reporting success with leftovers; set a join flush limit as before.

## Test plan
- [ ] FIFO queue, one message group, more than `max_messages` bodies, `exit_on_empty: true`, downstream that completes (not an unbounded join): run drains the queue instead of stopping after the first batch
- [ ] Standard queue `exit_on_empty` still stops on the first empty receive
- [ ] Unbounded join on FIFO no longer exits successfully with messages left behind (run keeps polling until a flush limit is set or the process is stopped)