### PR TITLE
fix(file): eliminate duplicate reads under task_concurrency

### DIFF
--- a/internal/pkg/pipeline/task/file/README.md
+++ b/internal/pkg/pipeline/task/file/README.md
@@ -37,7 +37,7 @@ In read mode, two values are stored in each record's context:
 | `tags` | map[string]string | - | S3 **write** only: object tags applied on `PutObject`. Ignored for local paths. Values support macros and context templates. See [S3 object tags](#s3-object-tags). |
 | `success_file` | bool | `false` | Whether to create a success file after writing |
 | `success_file_name` | string | `_SUCCESS` | Name of the success file |
-| `task_concurrency` | int | `1` | Number of competing-consumer workers for this task |
+| `task_concurrency` | int | `1` | Number of concurrent workers for this task. Write mode: competing consumers off the shared input channel. Read mode: the glob is expanded once and workers claim disjoint files off the matched list, so each file is still read exactly once. |
 | `context` | map | - | JQ expressions whose results are stored on each record for downstream tasks |
 | `fail_on_error` | bool | `false` | Whether to stop the pipeline if this task encounters an error |
 

--- a/internal/pkg/pipeline/task/file/file.go
+++ b/internal/pkg/pipeline/task/file/file.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/patterninc/caterpillar/internal/pkg/config"
 	"github.com/patterninc/caterpillar/internal/pkg/pipeline/ack"
@@ -50,6 +52,17 @@ type file struct {
 	StorageClass    storageClass             `yaml:"storage_class,omitempty" json:"storage_class,omitempty"`
 	Tags            map[string]config.String `yaml:"tags,omitempty" json:"tags,omitempty"`
 	Delimiter       string                   `yaml:"delimiter,omitempty" json:"delimiter,omitempty"`
+
+	// readOnce/readPaths/readErr/readReader/readIdx coordinate concurrent
+	// readers under task_concurrency > 1: the pipeline runs Run() N times
+	// concurrently on this same *file instance (see runTaskConcurrently), so
+	// the glob is expanded exactly once and workers claim disjoint paths off
+	// the shared slice via readIdx instead of each re-reading every file.
+	readOnce   sync.Once
+	readReader reader
+	readPaths  []string
+	readErr    error
+	readIdx    atomic.Int64
 }
 
 func New() (task.Task, error) {
@@ -96,18 +109,54 @@ func (f *file) Run(input <-chan *record.Record, output chan<- *record.Record) er
 
 }
 
+// readFile is invoked once per worker when task_concurrency > 1 (the pipeline
+// calls Run this many times concurrently on this same *file instance, sharing
+// the output channel — see runTaskConcurrently). The glob is only ever
+// expanded once, on whichever worker gets there first; every worker then
+// claims disjoint indices out of the shared path list via readIdx, so N
+// workers split the file list N ways instead of each reading every file.
 func (f *file) readFile(output chan<- *record.Record) error {
+
+	f.readOnce.Do(func() {
+		f.readReader, f.readPaths, f.readErr = f.newReader()
+	})
+
+	if f.readErr != nil {
+		return f.readErr
+	}
+
+	for {
+
+		idx := f.readIdx.Add(1) - 1
+		if idx >= int64(len(f.readPaths)) {
+			break
+		}
+
+		if err := f.readPath(f.readPaths[idx], output); err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+
+}
+
+// newReader resolves f.Path's glob into a scheme-appropriate reader and the
+// full list of matched paths. Called at most once per file instance, guarded
+// by readOnce in readFile.
+func (f *file) newReader() (reader, []string, error) {
 
 	// let's get the glob
 	glob, err := f.Path.Get(nil)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	// Determine the scheme from the path
 	parsedURL, err := url.Parse(glob)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	pathScheme := parsedURL.Scheme
 	if pathScheme == `` {
@@ -116,44 +165,47 @@ func (f *file) readFile(output chan<- *record.Record) error {
 
 	newReaderFunction, found := readers[pathScheme]
 	if !found {
-		return unknownSchemeError(pathScheme)
+		return nil, nil, unknownSchemeError(pathScheme)
 	}
 
 	// let's create a reader
-	reader, err := newReaderFunction(f)
+	rdr, err := newReaderFunction(f)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	// let's parse the glob to get all paths
-	paths, err := reader.parse(glob)
+	paths, err := rdr.parse(glob)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return rdr, paths, nil
+
+}
+
+// readPath reads a single matched path and sends its content to output.
+func (f *file) readPath(path string, output chan<- *record.Record) error {
+
+	readerCloser, err := f.readReader.read(path)
+	if err != nil {
+		return err
+	}
+	defer readerCloser.Close()
+
+	content, err := io.ReadAll(readerCloser)
 	if err != nil {
 		return err
 	}
 
-	for _, path := range paths {
+	// Create a default record with context
+	fileName := textutil.SlugifyFileName(filepath.Base(path))
+	rc := &record.Record{Context: ctx}
+	rc.SetContextValue(string(task.CtxKeyFileNameWrite), fileName)
+	rc.SetContextValue(string(task.CtxKeyFilePathWrite), textutil.SlugifyFilePath(path))
 
-		readerCloser, err := reader.read(path)
-		if err != nil {
-			return err
-		}
-		defer readerCloser.Close()
-
-		content, err := io.ReadAll(readerCloser)
-		if err != nil {
-			return err
-		}
-
-		// Create a default record with context
-		fileName := textutil.SlugifyFileName(filepath.Base(path))
-		rc := &record.Record{Context: ctx}
-		rc.SetContextValue(string(task.CtxKeyFileNameWrite), fileName)
-		rc.SetContextValue(string(task.CtxKeyFilePathWrite), textutil.SlugifyFilePath(path))
-
-		// let's write content to output channel
-		f.SendData(rc.Context, content, output)
-
-	}
+	// let's write content to output channel
+	f.SendData(rc.Context, content, output)
 
 	return nil
 
@@ -198,9 +250,19 @@ func (f *file) writeFile(input <-chan *record.Record) error {
 			pathScheme = fileScheme
 		}
 
-		var fs file
+		// only the fields writerFunction reads are copied here — f itself
+		// carries the sync.Once/atomic read-concurrency state (and the
+		// embedded task.Base mutex), which must never be struct-copied.
+		fs := &file{
+			Path:            f.Path,
+			SuccessFile:     f.SuccessFile,
+			SuccessFileName: f.SuccessFileName,
+			Region:          f.Region,
+			StorageClass:    f.StorageClass,
+			Tags:            f.Tags,
+			Delimiter:       f.Delimiter,
+		}
 
-		fs = *f
 		filePath, found := rc.GetContextValue(string(task.CtxKeyArchiveFileNameWrite))
 		if found {
 			if filePath == "" {
@@ -216,7 +278,7 @@ func (f *file) writeFile(input <-chan *record.Record) error {
 		if !found {
 			return f.abort(rc, unknownSchemeError(pathScheme))
 		}
-		if err := writerFunction(&fs, rc, bytes.NewReader(rc.Data)); err != nil {
+		if err := writerFunction(fs, rc, bytes.NewReader(rc.Data)); err != nil {
 			return f.abort(rc, err)
 		}
 

--- a/test/pipelines/file_concurrency_test.yaml
+++ b/test/pipelines/file_concurrency_test.yaml
@@ -1,0 +1,33 @@
+# Covers task_concurrency on the file task in both directions.
+#
+# Read mode: test/pipelines/*.txt matches 2 files. Before the fix, every one
+# of the 4 read workers independently expanded the glob and read every
+# matched file, so each file was emitted 4x. The glob is now expanded once
+# and workers claim disjoint files off the shared list via an atomic index,
+# so exactly 2 read records come out no matter how many workers run.
+#
+# Write mode: split explodes those 2 records into one per line, and 8 write
+# workers compete for the shared input channel. Each write targets a unique
+# {{ macro "uuid" }} filename, so the number of files landed in the output
+# directory is the ground truth for how many records were actually written —
+# it must equal the input line count exactly (no drops, no duplicates).
+#
+# Run directly, then verify the counts:
+#   rm -rf /tmp/caterpillar/file_concurrency_test
+#   ./caterpillar -conf test/pipelines/file_concurrency_test.yaml
+#   ls /tmp/caterpillar/file_concurrency_test | wc -l
+#   cat test/pipelines/names.txt test/pipelines/birds.txt | wc -l   # off by 2:
+#     # both fixture files end without a trailing newline, so the true line
+#     # count is this number of newlines plus 1 per file (currently 2121 + 2
+#     # = 2123 total).
+tasks:
+  - name: read_glob_concurrently
+    type: file
+    path: test/pipelines/*.txt
+    task_concurrency: 4
+  - name: split_to_lines
+    type: split
+  - name: write_concurrently
+    type: file
+    path: test/{{ macro "uuid" }}.txt
+    task_concurrency: 8

--- a/test/pipelines/file_concurrency_test.yaml
+++ b/test/pipelines/file_concurrency_test.yaml
@@ -1,25 +1,3 @@
-# Covers task_concurrency on the file task in both directions.
-#
-# Read mode: test/pipelines/*.txt matches 2 files. Before the fix, every one
-# of the 4 read workers independently expanded the glob and read every
-# matched file, so each file was emitted 4x. The glob is now expanded once
-# and workers claim disjoint files off the shared list via an atomic index,
-# so exactly 2 read records come out no matter how many workers run.
-#
-# Write mode: split explodes those 2 records into one per line, and 8 write
-# workers compete for the shared input channel. Each write targets a unique
-# {{ macro "uuid" }} filename, so the number of files landed in the output
-# directory is the ground truth for how many records were actually written —
-# it must equal the input line count exactly (no drops, no duplicates).
-#
-# Run directly, then verify the counts:
-#   rm -rf /tmp/caterpillar/file_concurrency_test
-#   ./caterpillar -conf test/pipelines/file_concurrency_test.yaml
-#   ls /tmp/caterpillar/file_concurrency_test | wc -l
-#   cat test/pipelines/names.txt test/pipelines/birds.txt | wc -l   # off by 2:
-#     # both fixture files end without a trailing newline, so the true line
-#     # count is this number of newlines plus 1 per file (currently 2121 + 2
-#     # = 2123 total).
 tasks:
   - name: read_glob_concurrently
     type: file

--- a/test/pipelines/file_concurrency_test.yaml
+++ b/test/pipelines/file_concurrency_test.yaml
@@ -29,5 +29,5 @@ tasks:
     type: split
   - name: write_concurrently
     type: file
-    path: test/{{ macro "uuid" }}.txt
+    path: /tmp/caterpillar/file_concurrency_test/{{ macro "uuid" }}.txt
     task_concurrency: 8


### PR DESCRIPTION
## Summary
- Fixes a correctness bug in the `file` task's read mode: when `task_concurrency > 1`, every worker independently expanded the glob and read every matched file, so each file was emitted once **per worker** instead of once total.
- The glob is now expanded exactly once (`sync.Once`), and workers claim disjoint files off the shared matched-path list via an atomic index (`readIdx`), so N workers split the file list N ways instead of each reading every file.
- `writeFile` now builds the per-worker `file` struct explicitly (only the fields the writer needs) instead of struct-copying `f`, since `f` now carries `sync.Once`/atomic read-concurrency state (and the embedded `task.Base` mutex) that must never be struct-copied.
- Updated the `task_concurrency` doc row in the task README to describe the read/write semantics precisely.

## Test plan
Added `test/pipelines/file_concurrency_test.yaml`, which exercises both directions in one pipeline:
- **Read**: `task_concurrency: 4` against a glob matching 2 fixture files (`names.txt`, `birds.txt`) — before the fix, 4 workers × 2 files = 8 read records; after the fix, exactly 2.
- **Write**: `task_concurrency: 8` writing one file per line after a `split` — output file count must exactly equal input line count (no drops, no duplicates).

Ran locally:
```
rm -rf /tmp/caterpillar/file_concurrency_test
go run cmd/caterpillar/caterpillar.go -conf test/pipelines/file_concurrency_test.yaml
ls /tmp/caterpillar/file_concurrency_test | wc -l   # 2123
cat test/pipelines/names.txt test/pipelines/birds.txt | wc -l   # 2121 newlines + 2 (no trailing newline in either fixture) = 2123
```
Output count matches expected exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)